### PR TITLE
Charm equip changes

### DIFF
--- a/libs/SoloPlay/BuildFiles/amazon.FrostmaidenBuild.js
+++ b/libs/SoloPlay/BuildFiles/amazon.FrostmaidenBuild.js
@@ -1,0 +1,125 @@
+/**
+*  @filename    amazon.FrostmaidenBuild.js
+*  @author      theBGuy
+*  @desc        Bowazon Cold/Strafe based final build
+*
+*/
+
+const finalBuild = {
+	caster: false,
+	skillstab: sdk.skills.tabs.BowandCrossbow,
+	wantedskills: [sdk.skills.Strafe, sdk.skills.FreezingArrow, sdk.skills.ExplodingArrow],
+	usefulskills: [sdk.skills.Penetrate, sdk.skills.Valkyrie, sdk.skills.Pierce, sdk.skills.IceArrow, sdk.skills.ColdArrow],
+	precastSkills: [sdk.skills.Valkyrie],
+	mercDiff: sdk.difficulty.Nightmare,
+	mercAct: 2,
+	mercAuraWanted: "Might",
+	stats: [
+		["strength", 156], ["dexterity", 152], ["vitality", 150], ["dexterity", "all"]
+	],
+	skills: [
+		[sdk.skills.Valkyrie, 1],
+		[sdk.skills.Strafe, 1],
+		[sdk.skills.Pierce, 1],
+		[sdk.skills.FreezingArrow, 20],
+		[sdk.skills.IceArrow, 20],
+		[sdk.skills.ColdArrow, 20],
+		[sdk.skills.Strafe, 20],
+		[sdk.skills.Valkyrie, 20],
+	],
+	autoEquipTiers: [ // autoequip final gear
+		// Weapon - Brand
+		"[name] == grandmatronbow && [flag] == runeword # [enhanceddamage] >= 260 && [itemknockback] == 1 && [itemdeadlystrike] == 20 # [tier] == 100000 + tierscore(item)",
+		// Helmet - Dream
+		"[type] == helm && [flag] == runeword # [holyshockaura] >= 15 # [tier] == 110000",
+		// Boots - War Traveler
+		"[name] == battleboots && [quality] == unique && [flag] != ethereal # [itemmagicbonus] >= 30 # [tier] == 100000",
+		// Belt - Nosferatu's Coil
+		"[name] == sharkskinbelt && [quality] == unique && [flag] != ethereal # [dexterity] == 15 # [tier] == 100000 + tierscore(item)",
+		// Armor - Chains of Honor
+		"[type] == armor && [flag] == runeword && [flag] != ethereal # [fireresist] == 65 # [tier] == 100000",
+		// Amulet - Highlords
+		"[type] == amulet && [quality] == unique # [lightresist] == 35 # [tier] == 110000",
+		// Rings - Ravenfrost & Carrion Wind
+		"[type] == ring && [quality] == unique # [dexterity] == 20 && [tohit] == 250 # [tier] == # [tier] == 110000", // Raven Frost
+		"[name] == ring && [quality] == unique # [poisonresist] == 55 && [lifeleech] >= 6 # [tier] == 110000", // Bul-Kathos' Wedding Band
+		// Switch
+		"[minimumsockets] >= 5 && [flag] == runeword # [plusskillbattleorders] >= 1 # [secondarytier] == 100000",
+		"[type] == shield # [itemallskills] >= 1 # [secondarytier] == 100000 + tierscore(item)", // Any 1+ all skill shield
+		"[type] == wand && [quality] >= normal # [itemchargedskill] == 82 # [secondarytier] == 75000 + chargeditemscore(item, 82)",	// Life Tap charged wand
+		// Merc
+		"[type] == armor && [flag] == runeword # [enhanceddefense] >= 200 && [enhanceddamage] >= 300 # [merctier] == 100000",	// Fortitude
+		"[name] == demonhead && [quality] == unique && [flag] != ethereal # [strength] >= 25 && [enhanceddefense] >= 100 # [merctier] == 40000 + mercscore(item)",	// Andy's
+		"[name] == demonhead && [quality] == unique && [flag] == ethereal # [strength] >= 25 && [enhanceddefense] >= 100 # [merctier] == 50000 + mercscore(item)",	// Eth Andy's
+	],
+
+	charms: {
+		ResLife: {
+			max: 3,
+			have: [],
+			classid: sdk.items.SmallCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid && check.allRes === 5 && check.getStat(sdk.stats.MaxHp) === 20);
+			}
+		},
+
+		ResMf: {
+			max: 2,
+			have: [],
+			classid: sdk.items.SmallCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid && check.allRes === 5 && check.getStat(sdk.stats.MagicBonus) === 7);
+			}
+		},
+
+		ResFHR: {
+			max: 1,
+			have: [],
+			classid: sdk.items.SmallCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid && check.allRes === 5 && check.getStat(sdk.stats.FHR) === 5);
+			}
+		},
+
+		SkillerCrossbow: {
+			max: 1,
+			have: [],
+			classid: sdk.items.GrandCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid && check.getStat(sdk.stats.AddSkillTab, sdk.skills.tabs.BowandCrossbow) === 1
+					&& check.getStat(sdk.stats.MaxHp) >= 40);
+			}
+		},
+
+		SkillerPassive: {
+			max: 1,
+			have: [],
+			classid: sdk.items.GrandCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid && check.getStat(sdk.stats.AddSkillTab, sdk.skills.tabs.PassiveandMagic) === 1
+					&& check.getStat(sdk.stats.MaxHp) >= 40);
+			}
+		},
+	},
+
+	AutoBuildTemplate: {
+		1:	{
+			Update: function () {
+				Config.AttackSkill = [-1, sdk.skills.FreezingArrow, -1, sdk.skills.FreezingArrow, -1, sdk.skills.Strafe, -1];
+				Config.LowManaSkill = [0, -1];
+			}
+		},
+	},
+
+	respec: function () {
+		if (me.classic) {
+			return false;
+		} else {
+			return me.haveAll([{name: sdk.locale.items.Dream, itemtype: sdk.itemtype.Helm}, {name: sdk.locale.items.Brand}, {name: sdk.locale.items.ChainsofHonor}]);
+		}
+	},
+
+	active: function () {
+		return this.respec && me.getSkill(sdk.skills.FreezingArrow, 0);
+	},
+};

--- a/libs/SoloPlay/BuildFiles/amazon.JavazonBuild.js
+++ b/libs/SoloPlay/BuildFiles/amazon.JavazonBuild.js
@@ -86,11 +86,6 @@ const finalBuild = {
 		// Rings - Raven Frost & Wisp
 		"[type] == ring && [quality] == unique # [dexterity] >= 15 && [tohit] >= 150 # [tier] == # [tier] == 100000",
 		"[type] == ring && [quality] == unique # [itemabsorblightpercent] >= 10 # [tier] == 100000",
-		// Charms
-		"[name] == smallcharm && [quality] == magic # [fireresist]+[lightresist]+[coldresist]+[poisonresist] >= 20 && [maxhp] >= 20 # [invoquantity] == 5 && [finalcharm] == true && [charmtier] == 1000 + charmscore(item)",
-		"[name] == smallcharm && [quality] == magic # [fireresist]+[lightresist]+[coldresist]+[poisonresist] >= 20 && [itemmagicbonus] >= 7 # [invoquantity] == 2 && [finalcharm] == true && [charmtier] == 1000 + charmscore(item)",
-		"[name] == smallcharm && [quality] == magic # [fireresist]+[lightresist]+[coldresist]+[poisonresist] >= 20 && [fhr] >= 5 # [invoquantity] == 1 && [finalcharm] == true && [charmtier] == 1000 + charmscore(item)",
-		"[name] == grandcharm && [quality] == magic # [javelinandspearskilltab] == 1 # [invoquantity] == 2 && [finalcharm] == true && [charmtier] == 1000 + charmscore(item)",
 		// Switch - CTA
 		"[minimumsockets] >= 5 && [flag] == runeword # [plusskillbattleorders] >= 1 # [secondarytier] == 100000",
 		// Switch - Spirit
@@ -106,6 +101,45 @@ const finalBuild = {
 	skills: undefined,
 	autoEquipTiers: undefined,
 
+	charms: {
+		ResLife: {
+			max: 5,
+			have: [],
+			classid: sdk.items.SmallCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid && check.allRes === 5 && check.getStat(sdk.stats.MaxHp) === 20);
+			}
+		},
+
+		ResMf: {
+			max: 2,
+			have: [],
+			classid: sdk.items.SmallCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid && check.allRes === 5 && check.getStat(sdk.stats.MagicBonus) === 7);
+			}
+		},
+
+		ResFHR: {
+			max: 1,
+			have: [],
+			classid: sdk.items.SmallCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid && check.allRes === 5 && check.getStat(sdk.stats.FHR) === 5);
+			}
+		},
+
+		Skiller: {
+			max: 2,
+			have: [],
+			classid: sdk.items.GrandCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid && check.getStat(sdk.stats.AddSkillTab, sdk.skills.tabs.JavelinandSpear) === 1
+					&& check.getStat(sdk.stats.MaxHp) >= 40);
+			}
+		},
+	},
+	
 	AutoBuildTemplate: {
 		1:	{
 			Update: function () {

--- a/libs/SoloPlay/BuildFiles/amazon.WitchyzonBuild.js
+++ b/libs/SoloPlay/BuildFiles/amazon.WitchyzonBuild.js
@@ -50,12 +50,6 @@ const finalBuild = {
 		// Rings - Raven Frost && Bul-Kathos' Wedding Band
 		"[type] == ring && [quality] == unique # [dexterity] >= 15 && [tohit] >= 150 # [tier] == # [tier] == 100000",
 		"[type] == ring && [quality] == unique # [maxstamina] == 50 && [lifeleech] >= 3 # [tier] == 100000",
-		// Charms
-		"[name] == smallcharm && [quality] == magic # [fireresist]+[lightresist]+[coldresist]+[poisonresist] >= 20 && [maxhp] >= 20 # [invoquantity] == 3 && [finalcharm] == true && [charmtier] == 1000 + charmscore(item)",
-		"[name] == smallcharm && [quality] == magic # [fireresist]+[lightresist]+[coldresist]+[poisonresist] >= 20 && [itemmagicbonus] >= 7 # [invoquantity] == 2 && [finalcharm] == true && [charmtier] == 1000 + charmscore(item)",
-		"[name] == smallcharm && [quality] == magic # [fireresist]+[lightresist]+[coldresist]+[poisonresist] >= 20 && [fhr] >= 5 # [invoquantity] == 1 && [finalcharm] == true && [charmtier] == 1000 + charmscore(item)",
-		"[name] == grandcharm && [quality] == magic # [bowandcrossbowskilltab] == 1 # [invoquantity] == 1 && [finalcharm] == true && [charmtier] == 1000 + charmscore(item)",
-		"[name] == grandcharm && [quality] == magic # [passiveandmagicskilltab] == 1 # [invoquantity] == 1 && [finalcharm] == true && [charmtier] == 1000 + charmscore(item)",
 		// Switch Final Weapon - CTA
 		"[minimumsockets] >= 5 && [flag] == runeword # [plusskillbattleorders] >= 1 # [secondarytier] == 100000",
 		// Switch Temporary Weapon - Life Tap charged wand
@@ -69,6 +63,55 @@ const finalBuild = {
 		// Merc Helmet - Andy's
 		"[name] == demonhead && [quality] == unique && [flag] != ethereal # [strength] >= 25 && [enhanceddefense] >= 100 # [merctier] == 50000 + mercscore(item)",
 	],
+
+	charms: {
+		ResLife: {
+			max: 3,
+			have: [],
+			classid: sdk.items.SmallCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid && check.allRes === 5 && check.getStat(sdk.stats.MaxHp) === 20);
+			}
+		},
+
+		ResMf: {
+			max: 2,
+			have: [],
+			classid: sdk.items.SmallCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid && check.allRes === 5 && check.getStat(sdk.stats.MagicBonus) === 7);
+			}
+		},
+
+		ResFHR: {
+			max: 1,
+			have: [],
+			classid: sdk.items.SmallCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid && check.allRes === 5 && check.getStat(sdk.stats.FHR) === 5);
+			}
+		},
+
+		SkillerCrossbow: {
+			max: 1,
+			have: [],
+			classid: sdk.items.GrandCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid && check.getStat(sdk.stats.AddSkillTab, sdk.skills.tabs.BowandCrossbow) === 1
+					&& check.getStat(sdk.stats.MaxHp) >= 40);
+			}
+		},
+
+		SkillerPassive: {
+			max: 1,
+			have: [],
+			classid: sdk.items.GrandCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid && check.getStat(sdk.stats.AddSkillTab, sdk.skills.tabs.PassiveandMagic) === 1
+					&& check.getStat(sdk.stats.MaxHp) >= 40);
+			}
+		},
+	},
 
 	AutoBuildTemplate: {
 		1:	{

--- a/libs/SoloPlay/BuildFiles/assassin.TrapsinBuild.js
+++ b/libs/SoloPlay/BuildFiles/assassin.TrapsinBuild.js
@@ -50,9 +50,9 @@ const finalBuild = {
 	],
 	autoEquipTiers: [ // autoequip final gear
 		// Final Weapon - Silence
-		"[type] == sword && [flag] == runeword # [itemallskills] == 2 && [ias] == 20 && [fireresist] == 75 # [tier] == 200000", 
+		"[type] == sword && [flag] == runeword # [itemallskills] == 2 && [ias] == 20 && [fireresist] == 75 # [tier] == 200000",
 		// Temporary Weapon - HotO
-		"[type] == mace && [flag] == runeword # [itemallskills] == 3 # [tier] == 100000", 
+		"[type] == mace && [flag] == runeword # [itemallskills] == 3 # [tier] == 100000",
 		// Helmet - Andy's
 		"[name] == demonhead && [quality] == unique && [flag] != ethereal # [strength] >= 25 && [enhanceddefense] >= 100 # [tier] == 100000 + tierscore(item)",
 		// Belt - Arach's
@@ -72,12 +72,6 @@ const finalBuild = {
 		"[type] == ring	&& [quality] == unique # [dexterity] == 20 # [tier] == 110000",
 		// Rings - Raven Frost
 		"[type] == ring	&& [quality] == unique # [dexterity] >= 15 # [tier] == 100000",
-		// Charms
-		"[name] == smallcharm && [quality] == magic # [fireresist]+[lightresist]+[coldresist]+[poisonresist] >= 20 && [maxhp] >= 20 # [invoquantity] == 3 && [finalcharm] == true && [charmtier] == 1000 + charmscore(item)",
-		"[name] == smallcharm && [quality] == magic # [fireresist]+[lightresist]+[coldresist]+[poisonresist] >= 20 && [itemmagicbonus] >= 7 # [invoquantity] == 2 && [finalcharm] == true && [charmtier] == 1000 + charmscore(item)",
-		"[name] == smallcharm && [quality] == magic # [fireresist]+[lightresist]+[coldresist]+[poisonresist] >= 20 && [fhr] >= 5 # [invoquantity] == 1 && [finalcharm] == true && [charmtier] == 1000 + charmscore(item)",
-		"[name] == smallcharm && [quality] == magic # [maxhp] == 20 && [maxmana] == 17 # [invoquantity] == 2 && [finalcharm] == true && [charmtier] == 1000 + charmscore(item)",
-		"[name] == grandcharm && [quality] == magic # [trapsskilltab] == 1 # [invoquantity] == 2 && [finalcharm] == true && [charmtier] == 1000 + charmscore(item)",
 		// Switch Final Weapon - CTA
 		"[minimumsockets] >= 5 && [flag] == runeword # [plusskillbattleorders] >= 1 # [secondarytier] == 100000",
 		// Switch Final Shield - Spirit
@@ -91,6 +85,54 @@ const finalBuild = {
 		// Merc Helmet - Andy's
 		"[name] == demonhead && [quality] == unique && [flag] != ethereal # [strength] >= 25 && [enhanceddefense] >= 100 # [merctier] == 40000 + mercscore(item)",
 	],
+
+	charms: {
+		ResLife: {
+			max: 3,
+			have: [],
+			classid: sdk.items.SmallCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid && check.allRes === 5 && check.getStat(sdk.stats.MaxHp) === 20);
+			}
+		},
+
+		ResMf: {
+			max: 2,
+			have: [],
+			classid: sdk.items.SmallCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid && check.allRes === 5 && check.getStat(sdk.stats.MagicBonus) === 7);
+			}
+		},
+
+		ResFHR: {
+			max: 1,
+			have: [],
+			classid: sdk.items.SmallCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid && check.allRes === 5 && check.getStat(sdk.stats.FHR) === 5);
+			}
+		},
+
+		LifeMana: {
+			max: 2,
+			have: [],
+			classid: sdk.items.SmallCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid && check.getStat(sdk.stats.MaxHp) === 20 && check.getStat(sdk.stats.MaxMana) === 17);
+			}
+		},
+
+		Skiller: {
+			max: 2,
+			have: [],
+			classid: sdk.items.GrandCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid && check.getStat(sdk.stats.AddSkillTab, sdk.skills.tabs.Traps) === 1
+					&& check.getStat(sdk.stats.MaxHp) >= 40);
+			}
+		},
+	},
 
 	AutoBuildTemplate: {
 		1:	{

--- a/libs/SoloPlay/BuildFiles/assassin.WhirlsinBuild.js
+++ b/libs/SoloPlay/BuildFiles/assassin.WhirlsinBuild.js
@@ -53,12 +53,6 @@ const finalBuild = {
 		// Rings - Raven Frost && Bul-Kathos' Wedding Band
 		"[type] == ring && [quality] == unique # [dexterity] >= 15 && [tohit] >= 150 # [tier] == # [tier] == 100000",
 		"[type] == ring && [quality] == unique # [maxstamina] == 50 && [lifeleech] >= 3 # [tier] == 100000",
-		// Charms
-		"[name] == smallcharm && [quality] == magic # [fireresist]+[lightresist]+[coldresist]+[poisonresist] >= 20 && [maxhp] >= 20 # [invoquantity] == 3 && [finalcharm] == true && [charmtier] == 1000 + charmscore(item)",
-		"[name] == smallcharm && [quality] == magic # [fireresist]+[lightresist]+[coldresist]+[poisonresist] >= 20 && [itemmagicbonus] >= 7 # [invoquantity] == 2 && [finalcharm] == true && [charmtier] == 1000 + charmscore(item)",
-		"[name] == smallcharm && [quality] == magic # [fireresist]+[lightresist]+[coldresist]+[poisonresist] >= 20 && [fhr] >= 5 # [invoquantity] == 1 && [finalcharm] == true && [charmtier] == 1000 + charmscore(item)",
-		"[name] == smallcharm && [quality] == magic # [maxhp] == 20 && [maxmana] == 17 # [invoquantity] == 2 && [finalcharm] == true && [charmtier] == 1000 + charmscore(item)",
-		"[name] == grandcharm && [quality] == magic # [trapsskilltab] == 1 # [invoquantity] == 2 && [finalcharm] == true && [charmtier] == 1000 + charmscore(item)",
 		// Switch Final Weapon - CTA
 		"[minimumsockets] >= 5 && [flag] == runeword # [plusskillbattleorders] >= 1 # [secondarytier] == 100000",
 		// Switch Final Shield - Spirit
@@ -72,6 +66,54 @@ const finalBuild = {
 		// Merc Helmet - Andy's
 		"[name] == demonhead && [quality] == unique && [flag] != ethereal # [strength] >= 25 && [enhanceddefense] >= 100 # [merctier] == 40000 + mercscore(item)",
 	],
+
+	charms: {
+		ResLife: {
+			max: 3,
+			have: [],
+			classid: sdk.items.SmallCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid && check.allRes === 5 && check.getStat(sdk.stats.MaxHp) === 20);
+			}
+		},
+
+		ResMf: {
+			max: 2,
+			have: [],
+			classid: sdk.items.SmallCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid && check.allRes === 5 && check.getStat(sdk.stats.MagicBonus) === 7);
+			}
+		},
+
+		ResFHR: {
+			max: 1,
+			have: [],
+			classid: sdk.items.SmallCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid && check.allRes === 5 && check.getStat(sdk.stats.FHR) === 5);
+			}
+		},
+
+		LifeMana: {
+			max: 2,
+			have: [],
+			classid: sdk.items.SmallCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid && check.getStat(sdk.stats.MaxHp) === 20 && check.getStat(sdk.stats.MaxMana) === 17);
+			}
+		},
+
+		Skiller: {
+			max: 1,
+			have: [],
+			classid: sdk.items.GrandCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid && check.getStat(sdk.stats.AddSkillTab, sdk.skills.tabs.ShadowDisciplines) === 1
+					&& check.getStat(sdk.stats.MaxHp) >= 40);
+			}
+		},
+	},
 
 	AutoBuildTemplate: {
 		1:	{

--- a/libs/SoloPlay/BuildFiles/barbarian.FrenzyBuild.js
+++ b/libs/SoloPlay/BuildFiles/barbarian.FrenzyBuild.js
@@ -7,7 +7,7 @@
 
 const finalBuild = {
 	caster: false,
-	skillstab: sdk.skills.tabs.CombatBarb,
+	skillstab: sdk.skills.tabs.BarbCombat,
 	wantedskills: [sdk.skills.BattleOrders, sdk.skills.Frenzy, sdk.skills.DoubleSwing],
 	usefulskills: [sdk.skills.NaturalResistance, sdk.skills.IronSkin, sdk.skills.IncreasedSpeed],
 	precastSkills: [sdk.skills.BattleOrders, sdk.skills.WarCry],

--- a/libs/SoloPlay/BuildFiles/barbarian.FrenzyBuild.js
+++ b/libs/SoloPlay/BuildFiles/barbarian.FrenzyBuild.js
@@ -65,13 +65,13 @@ const finalBuild = {
 	autoEquipTiers: [ // autoequip final gear
 		// Final Weapon - Grief & BoTD
 		"[name] == phaseblade && [flag] == runeword # [ias] >= 30 # [tier] == 100000",
-		"[name] == colossusblade && [flag] == runeword # [ias] >= 60 && [enhanceddamage] >= 350 # [tier] == 100000", 
+		"[name] == colossusblade && [flag] == runeword # [ias] >= 60 && [enhanceddamage] >= 350 # [tier] == 100000",
 		// Helmet - Arreat's Face
 		"[name] == slayerguard && [quality] == unique && [flag] != ethereal # [barbarianskills] == 2 # [tier] == 100000 + tierscore(item)",
 		// Belt - Dungo's
 		"[name] == mithrilcoil && [quality] == unique && [flag] != ethereal # [damageresist] >= 10 && [vitality] >= 30 # [tier] == 100000 + tierscore(item)",
 		// Boots - Gore Rider
-		"[name] == warboots && [quality] == unique && [flag] != ethereal # [enhanceddefense] >= 160 # [tier] == 100000 + tierscore(item)", 
+		"[name] == warboots && [quality] == unique && [flag] != ethereal # [enhanceddefense] >= 160 # [tier] == 100000 + tierscore(item)",
 		// Armor - Fortitude
 		"[type] == armor && [flag] != ethereal && [flag] == runeword # [enhanceddefense] >= 200 && [enhanceddamage] >= 30 # [tier] == 100000",
 		// Gloves - Laying of Hands
@@ -84,12 +84,6 @@ const finalBuild = {
 		// Rings - Raven Frost && Bul-Kathos' Wedding Band
 		"[type] == ring && [quality] == unique # [dexterity] >= 15 && [tohit] >= 150 # [tier] == # [tier] == 100000",
 		"[type] == ring && [quality] == unique # [maxstamina] == 50 && [lifeleech] >= 3 # [tier] == 100000",
-		// Charms
-		"[name] == smallcharm && [quality] == magic # [fireresist]+[lightresist]+[coldresist]+[poisonresist] >= 20 && [maxhp] >= 20 # [invoquantity] == 4 && [finalcharm] == true && [charmtier] == 1000 + charmscore(item)",
-		"[name] == smallcharm && [quality] == magic # [fireresist]+[lightresist]+[coldresist]+[poisonresist] >= 20 && [itemmagicbonus] >= 7 # [invoquantity] == 2 && [finalcharm] == true && [charmtier] == 1000 + charmscore(item)",
-		"[name] == smallcharm && [quality] == magic # [fireresist]+[lightresist]+[coldresist]+[poisonresist] >= 20 && [fhr] >= 5 # [invoquantity] == 2 && [finalcharm] == true && [charmtier] == 1000 + charmscore(item)",
-		"[name] == grandcharm && [quality] == magic # [masteriesskilltab] == 1 # [invoquantity] == 1 && [finalcharm] == true && [charmtier] == 1000 + charmscore(item)",
-		"[name] == grandcharm && [quality] == magic # [barbcombatskilltab] == 1 # [invoquantity] == 1 && [finalcharm] == true && [charmtier] == 1000 + charmscore(item)",
 		// Switch -  BO Sticks
 		"([type] == club || [type] == sword || [type] == knife || [type] == throwingknife || [type] == mace) && ([quality] == magic || [flag] == runeword) && [2handed] == 0 # [itemallskills]+[warcriesskilltab]+[barbarianskills] >= 1 # [secondarytier] == 100000 + secondaryscore(item)",
 		// Merc Armor - Fortitude
@@ -99,6 +93,55 @@ const finalBuild = {
 		// Merc Helmet - Andy's
 		"[name] == demonhead && [quality] == unique && [flag] != ethereal # [strength] >= 25 && [enhanceddefense] >= 100 # [merctier] == 40000 + mercscore(item)",
 	],
+
+	charms: {
+		ResLife: {
+			max: 4,
+			have: [],
+			classid: sdk.items.SmallCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid && check.allRes === 5 && check.getStat(sdk.stats.MaxHp) === 20);
+			}
+		},
+
+		ResMf: {
+			max: 2,
+			have: [],
+			classid: sdk.items.SmallCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid && check.allRes === 5 && check.getStat(sdk.stats.MagicBonus) === 7);
+			}
+		},
+
+		ResFHR: {
+			max: 2,
+			have: [],
+			classid: sdk.items.SmallCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid && check.allRes === 5 && check.getStat(sdk.stats.FHR) === 5);
+			}
+		},
+
+		SkillerCombat: {
+			max: 1,
+			have: [],
+			classid: sdk.items.GrandCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid && check.getStat(sdk.stats.AddSkillTab, sdk.skills.tabs.BarbCombat) === 1
+					&& check.getStat(sdk.stats.MaxHp) >= 40);
+			}
+		},
+
+		SkillerMasteries: {
+			max: 1,
+			have: [],
+			classid: sdk.items.GrandCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid && check.getStat(sdk.stats.AddSkillTab, sdk.skills.tabs.Masteries) === 1
+					&& check.getStat(sdk.stats.MaxHp) >= 40);
+			}
+		},
+	},
 
 	AutoBuildTemplate: {
 		1:	{

--- a/libs/SoloPlay/BuildFiles/barbarian.ImmortalwhirlBuild.js
+++ b/libs/SoloPlay/BuildFiles/barbarian.ImmortalwhirlBuild.js
@@ -48,11 +48,6 @@ const finalBuild = {
 		// Rings - Raven Frost && Bul-Kathos' Wedding Band
 		"[type] == ring && [quality] == unique # [dexterity] >= 15 && [tohit] >= 150 # [tier] == # [tier] == 100000",
 		"[type] == ring && [quality] == unique # [maxstamina] == 50 && [lifeleech] >= 3 # [tier] == 100000",
-		// Charms
-		"[name] == smallcharm && [quality] == magic # [fireresist]+[lightresist]+[coldresist]+[poisonresist] >= 20 && [maxhp] >= 20 # [invoquantity] == 3 && [finalcharm] == true && [charmtier] == 1000 + charmscore(item)",
-		"[name] == smallcharm && [quality] == magic # [fireresist]+[lightresist]+[coldresist]+[poisonresist] >= 20 && [itemmagicbonus] >= 7 # [invoquantity] == 2 && [finalcharm] == true && [charmtier] == 1000 + charmscore(item)",
-		"[name] == smallcharm && [quality] == magic # [fireresist]+[lightresist]+[coldresist]+[poisonresist] >= 20 && [fhr] >= 5 # [invoquantity] == 1 && [finalcharm] == true && [charmtier] == 1000 + charmscore(item)",
-		"[name] == grandcharm && [quality] == magic # [masteriesskilltab] == 1 # [invoquantity] == 2 && [finalcharm] == true && [charmtier] == charmscore(item)",
 		// Switch - BO sticks
 		"([type] == club || [type] == sword || [type] == knife || [type] == throwingknife || [type] == mace) && ([quality] == magic || [flag] == runeword) && [2handed] == 0 # [itemallskills]+[warcriesskilltab]+[barbarianskills] >= 1 # [secondarytier] == 100000 + secondaryscore(item)",
 		// Merc Armor - Fortitude
@@ -62,6 +57,45 @@ const finalBuild = {
 		// Merc Helmet - Andy's
 		"[name] == demonhead && [quality] == unique && [flag] != ethereal # [strength] >= 25 && [enhanceddefense] >= 100 # [merctier] == 40000 + mercscore(item)",
 	],
+
+	charms: {
+		ResLife: {
+			max: 3,
+			have: [],
+			classid: sdk.items.SmallCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid && check.allRes === 5 && check.getStat(sdk.stats.MaxHp) === 20);
+			}
+		},
+
+		ResMf: {
+			max: 2,
+			have: [],
+			classid: sdk.items.SmallCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid && check.allRes === 5 && check.getStat(sdk.stats.MagicBonus) === 7);
+			}
+		},
+
+		ResFHR: {
+			max: 1,
+			have: [],
+			classid: sdk.items.SmallCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid && check.allRes === 5 && check.getStat(sdk.stats.FHR) === 5);
+			}
+		},
+
+		Skiller: {
+			max: 2,
+			have: [],
+			classid: sdk.items.GrandCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid && check.getStat(sdk.stats.AddSkillTab, sdk.skills.tabs.Masteries) === 1
+					&& check.getStat(sdk.stats.MaxHp) >= 40);
+			}
+		},
+	},
 
 	AutoBuildTemplate: {
 		1:	{

--- a/libs/SoloPlay/BuildFiles/barbarian.ImmortalwhirlBuild.js
+++ b/libs/SoloPlay/BuildFiles/barbarian.ImmortalwhirlBuild.js
@@ -7,7 +7,7 @@
 
 const finalBuild = {
 	caster: false,
-	skillstab: sdk.skills.tabs.CombatBarb,
+	skillstab: sdk.skills.tabs.BarbCombat,
 	wantedskills: [sdk.skills.Bash, sdk.skills.Whirlwind],
 	usefulskills: [sdk.skills.Howl, sdk.skills.Shout],
 	precastSkills: [sdk.skills.BattleOrders, sdk.skills.WarCry], // Battle orders, War Cry

--- a/libs/SoloPlay/BuildFiles/barbarian.LevelingBuild.js
+++ b/libs/SoloPlay/BuildFiles/barbarian.LevelingBuild.js
@@ -8,7 +8,7 @@
 
 let build = {
 	caster: false,
-	skillstab: sdk.skills.tabs.CombatBarb,
+	skillstab: sdk.skills.tabs.BarbCombat,
 	wantedskills: [sdk.skills.BattleOrders, sdk.skills.Frenzy, sdk.skills.DoubleSwing, sdk.skills.SwordMastery],
 	usefulskills: [sdk.skills.NaturalResistance, sdk.skills.IronSkin, sdk.skills.IncreasedSpeed, sdk.skills.Shout, sdk.skills.FindItem],
 	mercDiff: sdk.difficulty.Nightmare,

--- a/libs/SoloPlay/BuildFiles/barbarian.SingerBuild.js
+++ b/libs/SoloPlay/BuildFiles/barbarian.SingerBuild.js
@@ -45,11 +45,6 @@ const finalBuild = {
 		"[type] == amulet && [quality] == unique # [strength] == 5 && [coldresist] >= 30 # [tier] == 100000 + tierscore(item)",
 		// Rings - SoJ
 		"[type] == ring && [quality] == unique # [itemmaxmanapercent] == 25 # [tier] == 100000",
-		// Charms
-		"[name] == smallcharm && [quality] == magic # [fireresist]+[lightresist]+[coldresist]+[poisonresist] >= 20 && [maxhp] >= 20 # [invoquantity] == 3 && [finalcharm] == true && [charmtier] == 1000 + charmscore(item)",
-		"[name] == smallcharm && [quality] == magic # [fireresist]+[lightresist]+[coldresist]+[poisonresist] >= 20 && [itemmagicbonus] >= 7 # [invoquantity] == 2 && [finalcharm] == true && [charmtier] == 1000 + charmscore(item)",
-		"[name] == smallcharm && [quality] == magic # [fireresist]+[lightresist]+[coldresist]+[poisonresist] >= 20 && [fhr] >= 5 # [invoquantity] == 1 && [finalcharm] == true && [charmtier] == 1000 + charmscore(item)",
-		"[name] == grandcharm && [quality] == magic # [warcriesskilltab] == 1 # [invoquantity] == 2 && [finalcharm] == true && [charmtier] == charmscore(item)",
 		// Switch - BO sticks
 		"([type] == club || [type] == sword || [type] == knife || [type] == throwingknife || [type] == mace) && ([quality] == magic || [flag] == runeword) && [2handed] == 0 # [itemallskills]+[warcriesskilltab]+[barbarianskills] >= 1 # [secondarytier] == 100000 + secondaryscore(item)",
 		// Merc Armor - Fortitude
@@ -59,6 +54,45 @@ const finalBuild = {
 		// Merc Helmet - Andy's
 		"[name] == demonhead && [quality] == unique && [flag] != ethereal # [strength] >= 25 && [enhanceddefense] >= 100 # [merctier] == 40000 + mercscore(item)",
 	],
+
+	charms: {
+		ResLife: {
+			max: 3,
+			have: [],
+			classid: sdk.items.SmallCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid && check.allRes === 5 && check.getStat(sdk.stats.MaxHp) === 20);
+			}
+		},
+
+		ResMf: {
+			max: 2,
+			have: [],
+			classid: sdk.items.SmallCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid && check.allRes === 5 && check.getStat(sdk.stats.MagicBonus) === 7);
+			}
+		},
+
+		ResFHR: {
+			max: 1,
+			have: [],
+			classid: sdk.items.SmallCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid && check.allRes === 5 && check.getStat(sdk.stats.FHR) === 5);
+			}
+		},
+
+		Skiller: {
+			max: 2,
+			have: [],
+			classid: sdk.items.GrandCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid && check.getStat(sdk.stats.AddSkillTab, sdk.skills.tabs.Warcries) === 1
+					&& check.getStat(sdk.stats.MaxHp) >= 40);
+			}
+		},
+	},
 
 	AutoBuildTemplate: {
 		1:	{

--- a/libs/SoloPlay/BuildFiles/barbarian.StartBuild.js
+++ b/libs/SoloPlay/BuildFiles/barbarian.StartBuild.js
@@ -8,7 +8,7 @@
 
 let build = {
 	caster: false,
-	skillstab: sdk.skills.tabs.CombatBarb,
+	skillstab: sdk.skills.tabs.BarbCombat,
 	wantedskills: [sdk.skills.BattleOrders, sdk.skills.Frenzy, sdk.skills.DoubleSwing, sdk.skills.SwordMastery],
 	usefulskills: [sdk.skills.NaturalResistance, sdk.skills.IronSkin, sdk.skills.IncreasedSpeed, sdk.skills.Shout],
 	mercDiff: sdk.difficulty.Nightmare,

--- a/libs/SoloPlay/BuildFiles/barbarian.SteppingBuild.js
+++ b/libs/SoloPlay/BuildFiles/barbarian.SteppingBuild.js
@@ -8,7 +8,7 @@
 
 let build = {
 	caster: false,
-	skillstab: sdk.skills.tabs.CombatBarb,
+	skillstab: sdk.skills.tabs.BarbCombat,
 	wantedskills: [sdk.skills.BattleOrders, sdk.skills.Frenzy, sdk.skills.DoubleSwing, sdk.skills.SwordMastery],
 	usefulskills: [sdk.skills.NaturalResistance, sdk.skills.IronSkin, sdk.skills.IncreasedSpeed, sdk.skills.Shout, sdk.skills.FindItem],
 	mercDiff: sdk.difficulty.Nightmare,

--- a/libs/SoloPlay/BuildFiles/barbarian.ThrowBuild.js
+++ b/libs/SoloPlay/BuildFiles/barbarian.ThrowBuild.js
@@ -55,12 +55,6 @@ const finalBuild = {
 		// Rings - Raven Frost && Bul-Kathos' Wedding Band
 		"[type] == ring && [quality] == unique # [dexterity] >= 15 && [tohit] >= 150 # [tier] == # [tier] == 100000",
 		"[type] == ring && [quality] == unique # [maxstamina] == 50 && [lifeleech] >= 3 # [tier] == 100000",
-		// Charms
-		"[name] == smallcharm && [quality] == magic # [fireresist]+[lightresist]+[coldresist]+[poisonresist] >= 20 && [maxhp] >= 20 # [invoquantity] == 4 && [finalcharm] == true && [charmtier] == 1000 + charmscore(item)",
-		"[name] == smallcharm && [quality] == magic # [fireresist]+[lightresist]+[coldresist]+[poisonresist] >= 20 && [itemmagicbonus] >= 7 # [invoquantity] == 2 && [finalcharm] == true && [charmtier] == 1000 + charmscore(item)",
-		"[name] == smallcharm && [quality] == magic # [fireresist]+[lightresist]+[coldresist]+[poisonresist] >= 20 && [fhr] >= 5 # [invoquantity] == 4 && [finalcharm] == true && [charmtier] == 1000 + charmscore(item)",
-		"[name] == grandcharm && [quality] == magic # [masteriesskilltab] == 1 # [invoquantity] == 1 && [finalcharm] == true && [charmtier] == 1000 + charmscore(item)",
-		"[name] == grandcharm && [quality] == magic # [barbcombatskilltab] == 1 # [invoquantity] == 1 && [finalcharm] == true && [charmtier] == 1000 + charmscore(item)",
 		// Switch - BO sticks
 		"([type] == club || [type] == sword || [type] == knife || [type] == throwingknife || [type] == mace) && ([quality] == magic || [flag] == runeword) && [2handed] == 0 # [itemallskills]+[warcriesskilltab]+[barbarianskills] >= 1 # [secondarytier] == 100000 + secondaryscore(item)",
 		// Merc Armor - Fortitude
@@ -70,6 +64,46 @@ const finalBuild = {
 		// Merc Helmet - Andy's
 		"[name] == demonhead && [quality] == unique && [flag] != ethereal # [strength] >= 25 && [enhanceddefense] >= 100 # [merctier] == 40000 + mercscore(item)",
 	],
+
+	charms: {
+		ResLife: {
+			max: 4,
+			have: [],
+			classid: sdk.items.SmallCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid && check.allRes === 5 && check.getStat(sdk.stats.MaxHp) === 20);
+			}
+		},
+
+		ResFHR: {
+			max: 4,
+			have: [],
+			classid: sdk.items.SmallCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid && check.allRes === 5 && check.getStat(sdk.stats.FHR) === 5);
+			}
+		},
+
+		SkillerCombat: {
+			max: 1,
+			have: [],
+			classid: sdk.items.GrandCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid && check.getStat(sdk.stats.AddSkillTab, sdk.skills.tabs.BarbCombat) === 1
+					&& check.getStat(sdk.stats.MaxHp) >= 40);
+			}
+		},
+
+		SkillerMasteries: {
+			max: 1,
+			have: [],
+			classid: sdk.items.GrandCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid && check.getStat(sdk.stats.AddSkillTab, sdk.skills.tabs.Masteries) === 1
+					&& check.getStat(sdk.stats.MaxHp) >= 40);
+			}
+		},
+	},
 
 	AutoBuildTemplate: {
 		1:	{

--- a/libs/SoloPlay/BuildFiles/barbarian.UberconcBuild.js
+++ b/libs/SoloPlay/BuildFiles/barbarian.UberconcBuild.js
@@ -49,10 +49,6 @@ const finalBuild = {
 		// Rings - Raven Frost && Bul-Kathos' Wedding Band
 		"[type] == ring && [quality] == unique # [dexterity] >= 15 && [tohit] >= 150 # [tier] == # [tier] == 100000",
 		"[name] == ring && [quality] == unique # [maxstamina] == 50 && [lifeleech] >= 3 # [tier] == 100000",
-		// Charms
-		"[name] == smallcharm && [quality] == magic # [fireresist]+[lightresist]+[coldresist]+[poisonresist] >= 20 && [maxhp] >= 20 # [invoquantity] == 6 && [finalcharm] == true && [charmtier] == 1000 + charmscore(item)",
-		"[name] == smallcharm && [quality] == magic # [fireresist]+[lightresist]+[coldresist]+[poisonresist] >= 20 && [itemmagicbonus] >= 7 # [invoquantity] == 2 && [finalcharm] == true && [charmtier] == 1000 + charmscore(item)",
-		"[name] == grandcharm && [quality] == magic # [barbcombatskilltab] == 1 # [invoquantity] == 2 && [finalcharm] == true && [charmtier] == 1000 + charmscore(item)",
 		// Switch - BO sticks
 		"([type] == club || [type] == sword || [type] == knife || [type] == throwingknife || [type] == mace) && ([quality] == magic || [flag] == runeword) && [2handed] == 0 # [itemallskills]+[warcriesskilltab]+[barbarianskills] >= 1 # [secondarytier] == 100000 + secondaryscore(item)",
 		// Merc Armor - Fortitude
@@ -62,6 +58,36 @@ const finalBuild = {
 		// Merc Helmet - Andy's
 		"[name] == demonhead && [quality] == unique && [flag] != ethereal # [strength] >= 25 && [enhanceddefense] >= 100 # [merctier] == 40000 + mercscore(item)",
 	],
+
+	charms: {
+		ResLife: {
+			max: 4,
+			have: [],
+			classid: sdk.items.SmallCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid && check.allRes === 5 && check.getStat(sdk.stats.MaxHp) === 20);
+			}
+		},
+
+		ResFHR: {
+			max: 4,
+			have: [],
+			classid: sdk.items.SmallCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid && check.allRes === 5 && check.getStat(sdk.stats.FHR) === 5);
+			}
+		},
+
+		Skiller: {
+			max: 2,
+			have: [],
+			classid: sdk.items.GrandCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid && check.getStat(sdk.stats.AddSkillTab, sdk.skills.tabs.BarbCombat) === 1
+					&& check.getStat(sdk.stats.MaxHp) >= 40);
+			}
+		},
+	},
 
 	AutoBuildTemplate: {
 		1:	{

--- a/libs/SoloPlay/BuildFiles/barbarian.WhirlwindBuild.js
+++ b/libs/SoloPlay/BuildFiles/barbarian.WhirlwindBuild.js
@@ -41,21 +41,16 @@ const finalBuild = {
 		"[name] == warboots && [quality] == unique && [flag] != ethereal # [enhanceddefense] >= 160 # [tier] == 100000 + tierscore(item)",
 		// Armor - Fortitude
 		"[type] == armor && [flag] != ethereal && [flag] == runeword # [enhanceddefense] >= 200 && [enhanceddamage] >= 30 # [tier] == 100000",
-		// Gloves
-		"[name] == bramblemitts && [quality] == set && [flag] != ethereal # [ias] == 20 # [tier] == 100000", // Laying of Hands
-		// Amulet
-		"[type] == amulet && [quality] == unique # [poisonresist] == 75 # [tier] == 100000 + tierscore(item)", // Atma's
+		// Gloves - Laying of Hands
+		"[name] == bramblemitts && [quality] == set && [flag] != ethereal # [ias] == 20 # [tier] == 100000",
+		// Amulet - Atma's
+		"[type] == amulet && [quality] == unique # [poisonresist] == 75 # [tier] == 100000 + tierscore(item)",
 		// Final Rings - Perfect Raven Frost & Bul-Kathos' Wedding Band
 		"[type] == ring && [quality] == unique # [dexterity] == 20 && [tohit] == 250 # [tier] == # [tier] == 110000",
 		"[type] == ring && [quality] == unique # [maxstamina] == 50 && [lifeleech] == 5 # [tier] == 110000",
 		// Rings - Raven Frost && Bul-Kathos' Wedding Band
 		"[type] == ring && [quality] == unique # [dexterity] >= 15 && [tohit] >= 150 # [tier] == # [tier] == 100000",
 		"[type] == ring && [quality] == unique # [maxstamina] == 50 && [lifeleech] >= 3 # [tier] == 100000",
-		// Charms
-		"[name] == smallcharm && [quality] == magic # [fireresist]+[lightresist]+[coldresist]+[poisonresist] >= 20 && [maxhp] >= 20 # [invoquantity] == 4 && [finalcharm] == true && [charmtier] == 1000 + charmscore(item)",
-		"[name] == smallcharm && [quality] == magic # [fireresist]+[lightresist]+[coldresist]+[poisonresist] >= 20 && [itemmagicbonus] >= 7 # [invoquantity] == 2 && [finalcharm] == true && [charmtier] == 1000 + charmscore(item)",
-		"[name] == smallcharm && [quality] == magic # [fireresist]+[lightresist]+[coldresist]+[poisonresist] >= 20 && [fhr] >= 5 # [invoquantity] == 2 && [finalcharm] == true && [charmtier] == 1000 + charmscore(item)",
-		"[name] == grandcharm && [quality] == magic # [masteriesskilltab] == 1 # [invoquantity] == 2 && [finalcharm] == true && [charmtier] == 1000 + charmscore(item)",
 		// Switch - BO sticks
 		"([type] == club || [type] == sword || [type] == knife || [type] == throwingknife || [type] == mace) && ([quality] == magic || [flag] == runeword) && [2handed] == 0 # [itemallskills]+[warcriesskilltab]+[barbarianskills] >= 1 # [secondarytier] == 100000 + secondaryscore(item)",
 		// Merc Armor - Fortitude
@@ -65,6 +60,45 @@ const finalBuild = {
 		// Merc Helmet - Andy's
 		"[name] == demonhead && [quality] == unique && [flag] != ethereal # [strength] >= 25 && [enhanceddefense] >= 100 # [merctier] == 40000 + mercscore(item)",
 	],
+
+	charms: {
+		ResLife: {
+			max: 4,
+			have: [],
+			classid: sdk.items.SmallCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid && check.allRes === 5 && check.getStat(sdk.stats.MaxHp) === 20);
+			}
+		},
+
+		ResMf: {
+			max: 2,
+			have: [],
+			classid: sdk.items.SmallCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid && check.allRes === 5 && check.getStat(sdk.stats.MagicBonus) === 7);
+			}
+		},
+
+		ResFHR: {
+			max: 2,
+			have: [],
+			classid: sdk.items.SmallCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid && check.allRes === 5 && check.getStat(sdk.stats.FHR) === 5);
+			}
+		},
+
+		Skiller: {
+			max: 2,
+			have: [],
+			classid: sdk.items.GrandCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid && check.getStat(sdk.stats.AddSkillTab, sdk.skills.tabs.Masteries) === 1
+					&& check.getStat(sdk.stats.MaxHp) >= 40);
+			}
+		},
+	},
 
 	AutoBuildTemplate: {
 		1:	{

--- a/libs/SoloPlay/BuildFiles/druid.ElementalBuild.js
+++ b/libs/SoloPlay/BuildFiles/druid.ElementalBuild.js
@@ -31,7 +31,7 @@ const finalBuild = {
 		[sdk.skills.OakSage, 20, false],
 		[sdk.skills.CycloneArmor, 20, false],
 		[sdk.skills.Grizzly, 5, false],
-    ],
+	],
 	autoEquipTiers: [ // autoequip final gear
 		// Weapon - HotO
 		"[type] == mace && [flag] == runeword # [itemallskills] == 3 # [tier] == 100000",
@@ -46,7 +46,7 @@ const finalBuild = {
 		// Armor - Enigma
 		"[type] == armor && [flag] != ethereal && [flag] == runeword # [itemallskills] == 2 # [tier] == 100000",
 		// Shield - Phoenix
-		"[name] == monarch && [flag] != ethereal && [flag] == runeword # [passivefirepierce] >= 28 # [tier] == 100000 + tierscore(item)", 
+		"[name] == monarch && [flag] != ethereal && [flag] == runeword # [passivefirepierce] >= 28 # [tier] == 100000 + tierscore(item)",
 		// Final Gloves - Perfect 2x Upp'ed Magefist
 		"[name] == crusadergauntlets && [quality] == unique && [flag] != ethereal # [enhanceddefense] == 30 && [addfireskills] == 1 # [tier] == 110000",
 		// Gloves - 2x Upp'ed Magefist
@@ -59,11 +59,6 @@ const finalBuild = {
 		"[type] == amulet && [quality] == unique # [strength] == 5 && [coldresist] >= 30 # [tier] == 100000 + tierscore(item)",
 		// Rings - SoJ
 		"[type] == ring && [quality] == unique # [itemmaxmanapercent] == 25 # [tier] == 100000",
-		// Charms
-		"[name] == smallcharm && [quality] == magic # [fireresist]+[lightresist]+[coldresist]+[poisonresist] >= 20 && [maxhp] >= 20 # [invoquantity] == 3 && [finalcharm] == true && [charmtier] == 1000 + charmscore(item)",
-		"[name] == smallcharm && [quality] == magic # [fireresist]+[lightresist]+[coldresist]+[poisonresist] >= 20 && [itemmagicbonus] >= 7 # [invoquantity] == 2 && [finalcharm] == true && [charmtier] == 1000 + charmscore(item)",
-		"[name] == smallcharm && [quality] == magic # [fireresist]+[lightresist]+[coldresist]+[poisonresist] >= 20 && [fhr] >= 5 # [invoquantity] == 1 && [finalcharm] == true && [charmtier] == 1000 + charmscore(item)",
-		"[name] == grandcharm && [quality] == magic # [elementalskilltab] == 1 # [invoquantity] == 2 && [finalcharm] == true && [charmtier] == 1000 + charmscore(item)",
 		// Switch - CTA
 		"[minimumsockets] >= 5 && [flag] == runeword # [plusskillbattleorders] >= 1 # [secondarytier] == 100000",
 		// Merc Armor - Fortitude
@@ -73,6 +68,45 @@ const finalBuild = {
 		// Merc Helmet - Andy's
 		"[name] == demonhead && [quality] == unique && [flag] != ethereal # [strength] >= 25 && [enhanceddefense] >= 100 # [merctier] == 40000 + mercscore(item)",
 	],
+
+	charms: {
+		ResLife: {
+			max: 3,
+			have: [],
+			classid: sdk.items.SmallCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid && check.allRes === 5 && check.getStat(sdk.stats.MaxHp) === 20);
+			}
+		},
+
+		ResMf: {
+			max: 2,
+			have: [],
+			classid: sdk.items.SmallCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid && check.allRes === 5 && check.getStat(sdk.stats.MagicBonus) === 7);
+			}
+		},
+
+		ResFHR: {
+			max: 1,
+			have: [],
+			classid: sdk.items.SmallCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid && check.allRes === 5 && check.getStat(sdk.stats.FHR) === 5);
+			}
+		},
+
+		Skiller: {
+			max: 2,
+			have: [],
+			classid: sdk.items.GrandCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid && check.getStat(sdk.stats.AddSkillTab, sdk.skills.tabs.Elemental) === 1
+					&& check.getStat(sdk.stats.MaxHp) >= 40);
+			}
+		},
+	},
 
 	AutoBuildTemplate: {
 		1:	{

--- a/libs/SoloPlay/BuildFiles/druid.FirewolfBuild.js
+++ b/libs/SoloPlay/BuildFiles/druid.FirewolfBuild.js
@@ -52,10 +52,6 @@ const finalBuild = {
 		"[type] == ring && [quality] == unique # [tohit] >= 180 && [dexterity] >= 15 # [tier] == 100000",
 		// Ring 2 - Carrion Wind
 		"[name] == ring && [quality] == unique # [poisonresist] == 55 && [lifeleech] >= 6 # [tier] == 110000 + tierscore(item)",
-		// Charms
-		"[name] == smallcharm && [quality] == magic # [fireresist]+[lightresist]+[coldresist]+[poisonresist] >= 20 && [itemmagicbonus] >= 7 # [invoquantity] == 2 && [finalcharm] == true && [charmtier] == 1000 + charmscore(item)",
-		"[name] == smallcharm && [quality] == magic # [poisonlength]*[poisonmaxdam]/256 >= 141 # [invoquantity] == 6 && [finalcharm] == true && [charmtier] == 1000 + charmscore(item)",
-		"[name] == grandcharm && [quality] == magic # [shapeshiftingskilltab] == 1 # [invoquantity] == 2 && [finalcharm] == true && [charmtier] == charmscore(item)",
 		// Merc
 		// Final Armor - Fortitude
 		"[type] == armor && [flag] == runeword # [enhanceddefense] >= 200 && [enhanceddamage] >= 300 # [merctier] == 100000",
@@ -70,6 +66,37 @@ const finalBuild = {
 		// Temporary Weapon - Reaper's Toll
 		"[name] == thresher && [quality] == unique # [enhanceddamage] >= 190 && [lifeleech] >= 11 # [merctier] == 50000 + mercscore(item)",
 	],
+
+	charms: {
+		ResMf: {
+			max: 2,
+			have: [],
+			classid: sdk.items.SmallCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid && check.allRes === 5 && check.getStat(sdk.stats.MagicBonus) === 7);
+			}
+		},
+
+		Poison: {
+			max: 6,
+			have: [],
+			classid: sdk.items.SmallCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid
+					&& ((check.getStat(sdk.stats.PoisonLength) * check.getStat(sdk.stats.PoisonMaxDamage)) / 256) >= 141);
+			}
+		},
+
+		Skiller: {
+			max: 2,
+			have: [],
+			classid: sdk.items.GrandCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid && check.getStat(sdk.stats.AddSkillTab, sdk.skills.tabs.ShapeShifting) === 1
+					&& check.getStat(sdk.stats.MaxHp) >= 40);
+			}
+		},
+	},
 
 	AutoBuildTemplate: {
 		1:	{

--- a/libs/SoloPlay/BuildFiles/druid.FirewolfBuild.js
+++ b/libs/SoloPlay/BuildFiles/druid.FirewolfBuild.js
@@ -1,0 +1,99 @@
+/**
+*  @filename    druid.FirewolfBuild.js
+*  @author      theBGuy
+*  @desc        Fireclaw/Rabies wolf final build
+*
+*/
+
+const finalBuild = {
+	caster: false,
+	skillstab: sdk.skills.tabs.ShapeShifting,
+	wantedskills: [sdk.skills.Werewolf, sdk.skills.Lycanthropy, sdk.skills.FireClaws],
+	usefulskills: [sdk.skills.HeartofWolverine, sdk.skills.Grizzly, sdk.skills.Rabies, sdk.skills.Volcano, sdk.skills.Fissure, sdk.skills.Firestorm],
+	precastSkills: [sdk.skills.Werewolf, sdk.skills.HeartofWolverine, sdk.skills.Grizzly],
+	usefulStats: [sdk.stats.PassiveFireMastery, sdk.stats.PassiveFirePierce, sdk.stats.PierceFire],
+	mercDiff: sdk.difficulty.Nightmare,
+	mercAct: 2,
+	mercAuraWanted: "Might",
+	stats: [
+		["strength", 156], ["dexterity", 136], ["vitality", "all"]
+	],
+	skills: [
+		[sdk.skills.Werewolf, 1, false],
+		[sdk.skills.Lycanthropy, 20, false],
+		[sdk.skills.PoisonCreeper, 1, false],
+		[sdk.skills.Grizzly, 1, false],
+		[sdk.skills.HeartofWolverine, 1, false],
+		[sdk.skills.Volcano, 1, false],
+		[sdk.skills.Fury, 1, false],
+		[sdk.skills.FireClaws, 20, false],
+		[sdk.skills.Rabies, 20, false],
+		[sdk.skills.Volcano, 20, false],
+		[sdk.skills.HeartofWolverine, 20, false],
+	],
+
+	// AutoEquip Final Gear
+	autoEquipTiers: [
+		// Weapon - Ice
+		"[name] == demoncrossbow && [flag] == runeword # [holyfreezeaura] == 18 # [tier] == 110000",
+		// Helmet - Jalal's Mane
+		"[name] == totemicmask && [quality] == unique # [druidskills] == 2 && [shapeshiftingskilltab] == 2 # [tier] == 110000 + tierscore(item)",
+		// Belt - Verdungo's
+		"[name] == mithrilcoil && [quality] == unique && [flag] != ethereal # [enhanceddefense] >= 90 # [tier] == 110000 + tierscore(item)",
+		// Armor - Chains of Honor
+		"[type] == armor && [flag] == runeword && [flag] != ethereal # [fireresist] == 65 && [hpregen] == 7 # [tier] == 110000",
+		// Gloves - Dracul's Grasp
+		"[name] == vampirebonegloves && [quality] == unique && [flag] != ethereal # [enhanceddefense] >= 90 # [tier] == 110000 + tierscore(item)",
+		// Boots - Goblin Toes
+		"[name] == lightplatedboots && [quality] == unique && [flag] != ethereal # [enhanceddefense] >= 50 # [tier] == 100000 + tierscore(item)",
+		// Amulet - Metalgrid
+		"[type] == amulet && [quality] == unique # [tohit] >= 400 && [coldresist] >= 25 # [tier] == 110000 + tierscore(item)",
+		// Ring 1 - Ravenfrost
+		"[type] == ring && [quality] == unique # [tohit] >= 180 && [dexterity] >= 15 # [tier] == 100000",
+		// Ring 2 - Carrion Wind
+		"[name] == ring && [quality] == unique # [poisonresist] == 55 && [lifeleech] >= 6 # [tier] == 110000 + tierscore(item)",
+		// Charms
+		"[name] == smallcharm && [quality] == magic # [fireresist]+[lightresist]+[coldresist]+[poisonresist] >= 20 && [itemmagicbonus] >= 7 # [invoquantity] == 2 && [finalcharm] == true && [charmtier] == 1000 + charmscore(item)",
+		"[name] == smallcharm && [quality] == magic # [poisonlength]*[poisonmaxdam]/256 >= 141 # [invoquantity] == 6 && [finalcharm] == true && [charmtier] == 1000 + charmscore(item)",
+		"[name] == grandcharm && [quality] == magic # [shapeshiftingskilltab] == 1 # [invoquantity] == 2 && [finalcharm] == true && [charmtier] == charmscore(item)",
+		// Merc
+		// Final Armor - Fortitude
+		"[type] == armor && [flag] == runeword # [enhanceddefense] >= 200 && [enhanceddamage] >= 300 # [merctier] == 100000",
+		// Temporary Armor - Treachery
+		"[type] == armor && [flag] == runeword # [ias] == 45 && [coldresist] == 30 # [merctier] == 50000 + mercscore(item)",
+		// Final Helm - Eth Andy's
+		"[name] == demonhead && [quality] == unique && [flag] == ethereal # [strength] >= 25 && [enhanceddefense] >= 100 # [merctier] == 50000 + mercscore(item)",
+		// Temporary Helm - Andy's
+		"[name] == demonhead && [quality] == unique && [flag] != ethereal # [strength] >= 25 && [enhanceddefense] >= 100 # [merctier] == 40000 + mercscore(item)",
+		// Final Weapon - Infinity
+		"[type] == polearm && [flag] == runeword # [convictionaura] >= 13 # [merctier] == 100000 + mercscore(item)",
+		// Temporary Weapon - Reaper's Toll
+		"[name] == thresher && [quality] == unique # [enhanceddamage] >= 190 && [lifeleech] >= 11 # [merctier] == 50000 + mercscore(item)",
+	],
+
+	AutoBuildTemplate: {
+		1:	{
+			Update: function () {
+				Config.BeltColumn = ["hp", "hp", "mp", "rv"];
+				Config.AttackSkill = [
+					sdk.skills.FeralRage,
+					sdk.skills.FireClaws, sdk.skills.Rabies,
+					sdk.skills.FireClaws, sdk.skills.Rabies,
+					sdk.skills.Fury, sdk.skills.Rabies
+				];
+				Config.LowManaSkill = [0, 0];
+				Config.Wereform = "Werewolf";
+				Config.SummonAnimal = "Grizzly";
+				Config.SummonSpirit = "Heart of Wolverine";
+			}
+		},
+	},
+
+	respec: function () {
+		return me.haveAll([{name: sdk.locale.items.Ice}, {name: sdk.locale.items.ChainsofHonor}]);
+	},
+
+	active: function () {
+		return this.respec && me.getSkill(sdk.skills.FireClaws, 0) === 20;
+	},
+};

--- a/libs/SoloPlay/BuildFiles/druid.PlaguewolfBuild.js
+++ b/libs/SoloPlay/BuildFiles/druid.PlaguewolfBuild.js
@@ -50,10 +50,6 @@ const finalBuild = {
 		// Rings - Wisp & Bul-Kathos' Wedding Band
 		"[type] == ring && [quality] == unique # [itemabsorblightpercent] >= 10 # [tier] == 100000",
 		"[type] == ring && [quality] == unique # [maxstamina] == 50 && [lifeleech] >= 3 # [tier] == 100000",
-		// Charms
-		"[name] == smallcharm && [quality] == magic # [fireresist]+[lightresist]+[coldresist]+[poisonresist] >= 20 && [itemmagicbonus] >= 7 # [invoquantity] == 2 && [finalcharm] == true && [charmtier] == 1000 + charmscore(item)",
-		"[name] == smallcharm && [quality] == magic # [poisonlength]*[poisonmaxdam]/256 >= 141 # [invoquantity] == 6 && [finalcharm] == true && [charmtier] == 1000 + charmscore(item)",
-		"[name] == grandcharm && [quality] == magic # [shapeshiftingskilltab] == 1 # [invoquantity] == 2 && [finalcharm] == true && [charmtier] == charmscore(item)",
 		// Merc Final Armor - Fortitude
 		"[type] == armor && [flag] == runeword # [enhanceddefense] >= 200 && [enhanceddamage] >= 300 # [merctier] == 100000",
 		// Merc Armor - Treachery
@@ -65,6 +61,37 @@ const finalBuild = {
 		// Merc Weapon - Reaper's Toll
 		"[name] == thresher && [quality] == unique # [enhanceddamage] >= 190 && [lifeleech] >= 11 # [merctier] == 100000 + mercscore(item)",
 	],
+
+	charms: {
+		ResMf: {
+			max: 2,
+			have: [],
+			classid: sdk.items.SmallCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid && check.allRes === 5 && check.getStat(sdk.stats.MagicBonus) === 7);
+			}
+		},
+
+		Poison: {
+			max: 6,
+			have: [],
+			classid: sdk.items.SmallCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid
+					&& ((check.getStat(sdk.stats.PoisonLength) * check.getStat(sdk.stats.PoisonMaxDamage)) / 256) >= 141);
+			}
+		},
+
+		Skiller: {
+			max: 2,
+			have: [],
+			classid: sdk.items.GrandCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid && check.getStat(sdk.stats.AddSkillTab, sdk.skills.tabs.ShapeShifting) === 1
+					&& check.getStat(sdk.stats.MaxHp) >= 40);
+			}
+		},
+	},
 
 	AutoBuildTemplate: {
 		1:	{

--- a/libs/SoloPlay/BuildFiles/druid.WindBuild.js
+++ b/libs/SoloPlay/BuildFiles/druid.WindBuild.js
@@ -53,11 +53,6 @@ const finalBuild = {
 		"[type] == amulet && [quality] == unique # [strength] == 5 && [coldresist] >= 30 # [tier] == 100000 + tierscore(item)",
 		// Rings - SoJ
 		"[type] == ring && [quality] == unique # [itemmaxmanapercent] == 25 # [tier] == 100000",
-		// Charms
-		"[name] == smallcharm && [quality] == magic # [fireresist]+[lightresist]+[coldresist]+[poisonresist] >= 20 && [maxhp] >= 20 # [invoquantity] == 3 && [finalcharm] == true && [charmtier] == 1000 + charmscore(item)",
-		"[name] == smallcharm && [quality] == magic # [fireresist]+[lightresist]+[coldresist]+[poisonresist] >= 20 && [itemmagicbonus] >= 7 # [invoquantity] == 2 && [finalcharm] == true && [charmtier] == 1000 + charmscore(item)",
-		"[name] == smallcharm && [quality] == magic # [fireresist]+[lightresist]+[coldresist]+[poisonresist] >= 20 && [fhr] >= 5 # [invoquantity] == 1 && [finalcharm] == true && [charmtier] == 1000 + charmscore(item)",
-		"[name] == grandcharm && [quality] == magic # [elementalskilltab] == 1 # [invoquantity] == 2 && [finalcharm] == true && [charmtier] == 1000 + charmscore(item)",
 		// Switch - CTA
 		"[minimumsockets] >= 5 && [flag] == runeword # [plusskillbattleorders] >= 1 # [secondarytier] == 100000",
 		// Merc Armor - Fortitude
@@ -69,6 +64,45 @@ const finalBuild = {
 		// Merc Weapon - Reaper's Toll
 		"[name] == thresher && [quality] == unique # [enhanceddamage] >= 190 && [lifeleech] >= 11 # [merctier] == 100000 + mercscore(item)",
 	],
+
+	charms: {
+		ResLife: {
+			max: 3,
+			have: [],
+			classid: sdk.items.SmallCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid && check.allRes === 5 && check.getStat(sdk.stats.MaxHp) === 20);
+			}
+		},
+
+		ResMf: {
+			max: 2,
+			have: [],
+			classid: sdk.items.SmallCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid && check.allRes === 5 && check.getStat(sdk.stats.MagicBonus) === 7);
+			}
+		},
+
+		ResFHR: {
+			max: 1,
+			have: [],
+			classid: sdk.items.SmallCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid && check.allRes === 5 && check.getStat(sdk.stats.FHR) === 5);
+			}
+		},
+
+		Skiller: {
+			max: 2,
+			have: [],
+			classid: sdk.items.GrandCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid && check.getStat(sdk.stats.AddSkillTab, sdk.skills.tabs.Elemental) === 1
+					&& check.getStat(sdk.stats.MaxHp) >= 40);
+			}
+		},
+	},
 
 	AutoBuildTemplate: {
 		1:	{

--- a/libs/SoloPlay/BuildFiles/druid.WolfBuild.js
+++ b/libs/SoloPlay/BuildFiles/druid.WolfBuild.js
@@ -44,11 +44,6 @@ const finalBuild = {
 		// Rings - Wisp & Bul-Kathos' Wedding Band
 		"[type] == ring && [quality] == unique # [itemabsorblightpercent] >= 10 # [tier] == 110000 + tierscore(item)",
 		"[type] == ring && [quality] == unique # [maxstamina] == 50 && [lifeleech] >= 3 # [tier] == 110000 + tierscore(item)",
-		// Charms
-		"[name] == smallcharm && [quality] == magic # [fireresist]+[lightresist]+[coldresist]+[poisonresist] >= 20 && [maxhp] >= 20 # [invoquantity] == 3 && [finalcharm] == true && [charmtier] == 1000 + charmscore(item)",
-		"[name] == smallcharm && [quality] == magic # [fireresist]+[lightresist]+[coldresist]+[poisonresist] >= 20 && [itemmagicbonus] >= 7 # [invoquantity] == 2 && [finalcharm] == true && [charmtier] == 1000 + charmscore(item)",
-		"[name] == smallcharm && [quality] == magic # [fireresist]+[lightresist]+[coldresist]+[poisonresist] >= 20 && [fhr] >= 5 # [invoquantity] == 1 && [finalcharm] == true && [charmtier] == 1000 + charmscore(item)",
-		"[name] == grandcharm && [quality] == magic # [shapeshiftingskilltab] == 1 # [invoquantity] == 2 && [finalcharm] == true && [charmtier] == 1000 + charmscore(item)",
 		// Merc Final Armor - Fortitude
 		"[type] == armor && [flag] == runeword # [enhanceddefense] >= 200 && [enhanceddamage] >= 300 # [merctier] == 100000",
 		// Merc Armor - Treachery
@@ -60,6 +55,45 @@ const finalBuild = {
 		// Merc Weapon - Reaper's Toll
 		"[name] == thresher && [quality] == unique # [enhanceddamage] >= 190 && [lifeleech] >= 11 # [merctier] == 100000 + mercscore(item)",
 	],
+
+	charms: {
+		ResLife: {
+			max: 3,
+			have: [],
+			classid: sdk.items.SmallCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid && check.allRes === 5 && check.getStat(sdk.stats.MaxHp) === 20);
+			}
+		},
+
+		ResMf: {
+			max: 2,
+			have: [],
+			classid: sdk.items.SmallCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid && check.allRes === 5 && check.getStat(sdk.stats.MagicBonus) === 7);
+			}
+		},
+
+		ResFHR: {
+			max: 1,
+			have: [],
+			classid: sdk.items.SmallCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid && check.allRes === 5 && check.getStat(sdk.stats.FHR) === 5);
+			}
+		},
+
+		Skiller: {
+			max: 2,
+			have: [],
+			classid: sdk.items.GrandCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid && check.getStat(sdk.stats.AddSkillTab, sdk.skills.tabs.ShapeShifting) === 1
+					&& check.getStat(sdk.stats.MaxHp) >= 40);
+			}
+		},
+	},
 
 	AutoBuildTemplate: {
 		1:	{

--- a/libs/SoloPlay/BuildFiles/necromancer.BoneBuild.js
+++ b/libs/SoloPlay/BuildFiles/necromancer.BoneBuild.js
@@ -55,7 +55,7 @@ const finalBuild = {
 		// Weapon
 		"([type] == wand || [type] == sword && ([quality] >= magic || [flag] == runeword) || [type] == knife && [quality] >= magic) && [flag] != ethereal # [secondarymindamage] == 0 && [itemchargedskill] >= 0 # [tier] == tierscore(item)",
 		// Helmet - Harlequin's Crest
-		"[name] == shako && [quality] == unique && [flag] != ethereal # [damageresist] == 10 # [tier] == 100000 + tierscore(item)", 
+		"[name] == shako && [quality] == unique && [flag] != ethereal # [damageresist] == 10 # [tier] == 100000 + tierscore(item)",
 		// Belt - Arach's
 		"[name] == spiderwebsash && [quality] == unique && [flag] != ethereal # [enhanceddefense] >= 90 # [tier] == 100000 + tierscore(item)",
 		// Final Boots - Sandstorm Treks
@@ -79,11 +79,6 @@ const finalBuild = {
 		// Rings - Dwarf Star & SoJ
 		"[type] == ring && [quality] == unique # [maxhp] >= 40 && [magicdamagereduction] >= 12 # [tier] == 99000",
 		"[type] == ring && [quality] == unique # [itemmaxmanapercent] == 25 # [tier] == 100000",
-		// Charms
-		"[name] == smallcharm && [quality] == magic # [fireresist]+[lightresist]+[coldresist]+[poisonresist] >= 20 && [maxhp] >= 20 # [invoquantity] == 4 && [finalcharm] == true && [charmtier] == 1000 + charmscore(item)",
-		"[name] == smallcharm && [quality] == magic # [fireresist]+[lightresist]+[coldresist]+[poisonresist] >= 20 && [itemmagicbonus] >= 7 # [invoquantity] == 3 && [finalcharm] == true && [charmtier] == 1000 + charmscore(item)",
-		"[name] == smallcharm && [quality] == magic # [fireresist]+[lightresist]+[coldresist]+[poisonresist] >= 20 && [fhr] >= 5 # [invoquantity] == 1 && [finalcharm] == true && [charmtier] == 1000 + charmscore(item)",
-		"[name] == grandcharm && [quality] == magic # [poisonandboneskilltab] == 1 # [invoquantity] == 2 && [finalcharm] == true && [charmtier] == 1000 + charmscore(item)",
 		// Switch - CTA
 		"[minimumsockets] >= 5 && [flag] == runeword # [plusskillbattleorders] >= 1 # [secondarytier] == 100000",
 		// Switch - Spirit
@@ -97,6 +92,45 @@ const finalBuild = {
 	],
 	stats: undefined,
 	autoEquipTiers: undefined,
+
+	charms: {
+		ResLife: {
+			max: 4,
+			have: [],
+			classid: sdk.items.SmallCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid && check.allRes === 5 && check.getStat(sdk.stats.MaxHp) === 20);
+			}
+		},
+
+		ResMf: {
+			max: 3,
+			have: [],
+			classid: sdk.items.SmallCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid && check.allRes === 5 && check.getStat(sdk.stats.MagicBonus) === 7);
+			}
+		},
+
+		ResFHR: {
+			max: 1,
+			have: [],
+			classid: sdk.items.SmallCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid && check.allRes === 5 && check.getStat(sdk.stats.FHR) === 5);
+			}
+		},
+
+		Skiller: {
+			max: 2,
+			have: [],
+			classid: sdk.items.GrandCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid && check.getStat(sdk.stats.AddSkillTab, sdk.skills.tabs.PoisonandBone) === 1
+					&& check.getStat(sdk.stats.MaxHp) >= 40);
+			}
+		},
+	},
 
 	AutoBuildTemplate: {
 		1:	{

--- a/libs/SoloPlay/BuildFiles/necromancer.PoisonBuild.js
+++ b/libs/SoloPlay/BuildFiles/necromancer.PoisonBuild.js
@@ -80,11 +80,6 @@ const finalBuild = {
 		// Rings - Dwarf Star & SoJ
 		"[name] == ring && [quality] == unique # [maxhp] >= 40 && [magicdamagereduction] >= 12 # [tier] == 99000",
 		"[type] == ring && [quality] == unique # [itemmaxmanapercent] == 25 # [tier] == 100000",
-		// Charms
-		"[name] == smallcharm && [quality] == magic # [fireresist]+[lightresist]+[coldresist]+[poisonresist] >= 20 && [maxhp] >= 20 # [invoquantity] == 4 && [finalcharm] == true && [charmtier] == 1000 + charmscore(item)",
-		"[name] == smallcharm && [quality] == magic # [fireresist]+[lightresist]+[coldresist]+[poisonresist] >= 20 && [itemmagicbonus] >= 7 # [invoquantity] == 2 && [finalcharm] == true && [charmtier] == 1000 + charmscore(item)",
-		"[name] == smallcharm && [quality] == magic # [fireresist]+[lightresist]+[coldresist]+[poisonresist] >= 20 && [fhr] >= 5 # [invoquantity] == 1 && [finalcharm] == true && [charmtier] == 1000 + charmscore(item)",
-		"[name] == grandcharm && [quality] == magic # [poisonandboneskilltab] == 1 # [invoquantity] == 2 && [finalcharm] == true && [charmtier] == 1000 + charmscore(item)",
 		// Switch - CTA
 		"[minimumsockets] >= 5 && [flag] == runeword # [plusskillbattleorders] >= 1 # [secondarytier] == 100000",
 		// Switch - Spirit
@@ -99,6 +94,45 @@ const finalBuild = {
 	stats: undefined,
 	autoEquipTiers: undefined,
 
+	charms: {
+		ResLife: {
+			max: 4,
+			have: [],
+			classid: sdk.items.SmallCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid && check.allRes === 5 && check.getStat(sdk.stats.MaxHp) === 20);
+			}
+		},
+
+		ResMf: {
+			max: 2,
+			have: [],
+			classid: sdk.items.SmallCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid && check.allRes === 5 && check.getStat(sdk.stats.MagicBonus) === 7);
+			}
+		},
+
+		ResFHR: {
+			max: 2,
+			have: [],
+			classid: sdk.items.SmallCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid && check.allRes === 5 && check.getStat(sdk.stats.FHR) === 5);
+			}
+		},
+
+		Skiller: {
+			max: 2,
+			have: [],
+			classid: sdk.items.GrandCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid && check.getStat(sdk.stats.AddSkillTab, sdk.skills.tabs.PoisonandBone) === 1
+					&& check.getStat(sdk.stats.MaxHp) >= 40);
+			}
+		},
+	},
+	
 	AutoBuildTemplate: {
 		1:	{
 			Update: function () {

--- a/libs/SoloPlay/BuildFiles/necromancer.SummonBuild.js
+++ b/libs/SoloPlay/BuildFiles/necromancer.SummonBuild.js
@@ -93,10 +93,6 @@ const finalBuild = {
 		// Rings - Dwarf Star & Raven Frost
 		"[name] == ring && [quality] == unique # [maxhp] >= 40 && [magicdamagereduction] >= 12 # [tier] == 99000",
 		"[type] == ring && [quality] == unique # [dexterity] >= 20 # [tier] == 99000",
-		// Charms
-		"[name] == smallcharm && [quality] == magic # [fireresist]+[lightresist]+[coldresist]+[poisonresist] >= 20 && [maxhp] >= 20 # [invoquantity] == 4 && [finalcharm] == true && [charmtier] == 1000 + charmscore(item)",
-		"[name] == smallcharm && [quality] == magic # [fireresist]+[lightresist]+[coldresist]+[poisonresist] >= 20 && [itemmagicbonus] >= 7 # [invoquantity] == 4 && [finalcharm] == true && [charmtier] == 1000 + charmscore(item)",
-		"[name] == grandcharm && [quality] == magic # [necromancersummoningskilltab] == 1 # [invoquantity] == 2 && [finalcharm] == true && [charmtier] == 1000 + charmscore(item)",
 		// Switch - CTA
 		"[minimumsockets] >= 5 && [flag] == runeword # [plusskillbattleorders] >= 1 # [secondarytier] == 100000",
 		// Switch - Spirit
@@ -111,6 +107,36 @@ const finalBuild = {
 	stats: undefined,
 	skills: undefined,
 	autoEquipTiers: undefined,
+
+	charms: {
+		ResLife: {
+			max: 4,
+			have: [],
+			classid: sdk.items.SmallCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid && check.allRes === 5 && check.getStat(sdk.stats.MaxHp) === 20);
+			}
+		},
+
+		ResMf: {
+			max: 4,
+			have: [],
+			classid: sdk.items.SmallCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid && check.allRes === 5 && check.getStat(sdk.stats.MagicBonus) === 7);
+			}
+		},
+
+		Skiller: {
+			max: 2,
+			have: [],
+			classid: sdk.items.GrandCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid && check.getStat(sdk.stats.AddSkillTab, sdk.skills.tabs.NecroSummoning) === 1
+					&& check.getStat(sdk.stats.MaxHp) >= 40);
+			}
+		},
+	},
 
 	AutoBuildTemplate: {
 		1:	{

--- a/libs/SoloPlay/BuildFiles/paladin.AuradinBuild.js
+++ b/libs/SoloPlay/BuildFiles/paladin.AuradinBuild.js
@@ -55,10 +55,10 @@ const finalBuild = {
 		"[type] == ring && [quality] == unique # [dexterity] >= 15 && [tohit] >= 150 # [tier] == # [tier] == 100000",
 		"[type] == ring && [quality] == unique # [maxstamina] == 50 && [lifeleech] >= 3 # [tier] == 100000",
 		// Charms
-		"[name] == smallcharm && [quality] == magic # [fireresist]+[lightresist]+[coldresist]+[poisonresist] >= 20 && [maxhp] >= 20 # [invoquantity] == 6 && [finalcharm] == true && [charmtier] == 1000 + charmscore(item)",
-		"[name] == smallcharm && [quality] == magic # [fireresist]+[lightresist]+[coldresist]+[poisonresist] >= 20 && [itemmagicbonus] >= 7 # [invoquantity] == 2 && [finalcharm] == true && [charmtier] == 1000 + charmscore(item)",
-		"[name] == grandcharm && [quality] == magic # [offensiveaurasskilltab] == 1 # [invoquantity] == 2 && [finalcharm] == true && [charmtier] == 1000 + charmscore(item)",
-		// Switch - CTA
+		//"[name] == smallcharm && [quality] == magic # [fireresist]+[lightresist]+[coldresist]+[poisonresist] >= 20 && [maxhp] >= 20 # [invoquantity] == 6 && [finalcharm] == true && [charmtier] == 1000 + charmscore(item)",
+		//"[name] == smallcharm && [quality] == magic # [fireresist]+[lightresist]+[coldresist]+[poisonresist] >= 20 && [itemmagicbonus] >= 7 # [invoquantity] == 2 && [finalcharm] == true && [charmtier] == 1000 + charmscore(item)",
+		//"[name] == grandcharm && [quality] == magic # [offensiveaurasskilltab] == 1 # [invoquantity] == 2 && [finalcharm] == true && [charmtier] == 1000 + charmscore(item)",
+		// Switch
 		"[minimumsockets] >= 5 && [flag] == runeword # [plusskillbattleorders] >= 1 # [secondarytier] == 100000",
 		// Merc Final Armor - Fortitude
 		"[type] == armor && [flag] == runeword # [enhanceddefense] >= 200 && [enhanceddamage] >= 300 # [merctier] == 100000",
@@ -69,6 +69,36 @@ const finalBuild = {
 		// Merc Helmet - Andy's
 		"[name] == demonhead && [quality] == unique && [flag] != ethereal # [strength] >= 25 && [enhanceddefense] >= 100 # [merctier] == 40000 + mercscore(item)",
 	],
+
+	charms: {
+		ResLife: {
+			max: 6,
+			have: [],
+			classid: sdk.items.SmallCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid && check.allRes === 5 && check.getStat(sdk.stats.MaxHp) === 20);
+			}
+		},
+
+		ResMf: {
+			max: 2,
+			have: [],
+			classid: sdk.items.SmallCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid && check.allRes === 5 && check.getStat(sdk.stats.MagicBonus) === 7);
+			}
+		},
+
+		Skiller: {
+			max: 2,
+			have: [],
+			classid: sdk.items.GrandCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid && check.getStat(sdk.stats.AddSkillTab, sdk.skills.tabs.Offensive) === 1
+					&& check.getStat(sdk.stats.MaxHp) >= 40);
+			}
+		},
+	},
 
 	AutoBuildTemplate: {
 		1:	{

--- a/libs/SoloPlay/BuildFiles/paladin.AuradinBuild.js
+++ b/libs/SoloPlay/BuildFiles/paladin.AuradinBuild.js
@@ -54,11 +54,7 @@ const finalBuild = {
 		// Rings - Raven Frost && Bul-Kathos' Wedding Band
 		"[type] == ring && [quality] == unique # [dexterity] >= 15 && [tohit] >= 150 # [tier] == # [tier] == 100000",
 		"[type] == ring && [quality] == unique # [maxstamina] == 50 && [lifeleech] >= 3 # [tier] == 100000",
-		// Charms
-		//"[name] == smallcharm && [quality] == magic # [fireresist]+[lightresist]+[coldresist]+[poisonresist] >= 20 && [maxhp] >= 20 # [invoquantity] == 6 && [finalcharm] == true && [charmtier] == 1000 + charmscore(item)",
-		//"[name] == smallcharm && [quality] == magic # [fireresist]+[lightresist]+[coldresist]+[poisonresist] >= 20 && [itemmagicbonus] >= 7 # [invoquantity] == 2 && [finalcharm] == true && [charmtier] == 1000 + charmscore(item)",
-		//"[name] == grandcharm && [quality] == magic # [offensiveaurasskilltab] == 1 # [invoquantity] == 2 && [finalcharm] == true && [charmtier] == 1000 + charmscore(item)",
-		// Switch
+		// Switch - CTA
 		"[minimumsockets] >= 5 && [flag] == runeword # [plusskillbattleorders] >= 1 # [secondarytier] == 100000",
 		// Merc Final Armor - Fortitude
 		"[type] == armor && [flag] == runeword # [enhanceddefense] >= 200 && [enhanceddamage] >= 300 # [merctier] == 100000",
@@ -107,7 +103,7 @@ const finalBuild = {
 				Config.AttackSkill = [-1, sdk.skills.Zeal, sdk.skills.Conviction, sdk.skills.Zeal, sdk.skills.Conviction, -1, -1];
 				Config.LowManaSkill = [-1, -1];
 
-				if (!Check.haveItem("sword", "runeword", "Hand of Justice") || !Check.haveItem("armor", "runeword", "Dragon")) {
+				if (!me.haveSome([{name: sdk.locale.items.Dragon, itemtype: sdk.itemtype.Armor}, {name: sdk.locale.items.HandofJustice}])) {
 					Config.SkipImmune = ["lightning and physical"];
 				} else {
 					Config.SkipImmune = ["lightning and fire and physical"];	// Don't think this ever happens but should skip if it does

--- a/libs/SoloPlay/BuildFiles/paladin.ClassicauradinBuild.js
+++ b/libs/SoloPlay/BuildFiles/paladin.ClassicauradinBuild.js
@@ -77,10 +77,6 @@ const finalBuild = {
 		// Rings - Raven Frost && Bul-Kathos' Wedding Band
 		"[type] == ring && [quality] == unique # [dexterity] >= 15 && [tohit] >= 150 # [tier] == # [tier] == 100000",
 		"[type] == ring && [quality] == unique # [maxstamina] == 50 && [lifeleech] >= 3 # [tier] == 100000",
-		// Charms
-		"[name] == smallcharm && [quality] == magic # [fireresist]+[lightresist]+[coldresist]+[poisonresist] >= 20 && [maxhp] >= 20 # [invoquantity] == 6 && [finalcharm] == true && [charmtier] == 1000 + charmscore(item)",
-		"[name] == smallcharm && [quality] == magic # [fireresist]+[lightresist]+[coldresist]+[poisonresist] >= 20 && [itemmagicbonus] >= 7 # [invoquantity] == 2 && [finalcharm] == true && [charmtier] == 1000 + charmscore(item)",
-		"[name] == grandcharm && [quality] == magic # [offensiveaurasskilltab] == 1 # [invoquantity] == 2 && [finalcharm] == true && [charmtier] == 1000 + charmscore(item)",
 		// Switch - CTA
 		"[minimumsockets] >= 5 && [flag] == runeword # [plusskillbattleorders] >= 1 # [secondarytier] == 100000",
 		// Merc Final Armor - Fortitude
@@ -95,6 +91,36 @@ const finalBuild = {
 	stats: undefined,
 	autoEquipTiers: undefined,
 
+	charms: {
+		ResLife: {
+			max: 6,
+			have: [],
+			classid: sdk.items.SmallCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid && check.allRes === 5 && check.getStat(sdk.stats.MaxHp) === 20);
+			}
+		},
+
+		ResMf: {
+			max: 2,
+			have: [],
+			classid: sdk.items.SmallCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid && check.allRes === 5 && check.getStat(sdk.stats.MagicBonus) === 7);
+			}
+		},
+
+		Skiller: {
+			max: 2,
+			have: [],
+			classid: sdk.items.GrandCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid && check.getStat(sdk.stats.AddSkillTab, sdk.skills.tabs.Offensive) === 1
+					&& check.getStat(sdk.stats.MaxHp) >= 40);
+			}
+		},
+	},
+	
 	AutoBuildTemplate: {
 		1:	{
 			Update: function () {

--- a/libs/SoloPlay/BuildFiles/paladin.HammerdinBuild.js
+++ b/libs/SoloPlay/BuildFiles/paladin.HammerdinBuild.js
@@ -79,11 +79,6 @@ const finalBuild = {
 		// Rings - Dwarf Star & Raven Frost
 		"[name] == ring && [quality] == unique # [maxhp] >= 40 && [magicdamagereduction] >= 12 # [tier] == 99000",
 		"[type] == ring && [quality] == unique # [dexterity] >= 20 # [tier] == 99000",
-		// Charms
-		"[name] == smallcharm && [quality] == magic # [fireresist]+[lightresist]+[coldresist]+[poisonresist] >= 20 && [maxhp] >= 20 # [invoquantity] == 3 && [finalcharm] == true && [charmtier] == 1000 + charmscore(item)",
-		"[name] == smallcharm && [quality] == magic # [fireresist]+[lightresist]+[coldresist]+[poisonresist] >= 20 && [itemmagicbonus] >= 7 # [invoquantity] == 2 && [finalcharm] == true && [charmtier] == 1000 + charmscore(item)",
-		"[name] == smallcharm && [quality] == magic # [fireresist]+[lightresist]+[coldresist]+[poisonresist] >= 20 && [fhr] >= 5 # [invoquantity] == 1 && [finalcharm] == true && [charmtier] == 1000 + charmscore(item)",
-		"[name] == grandcharm && [quality] == magic # [palicombatskilltab] == 1 # [invoquantity] == 2 && [finalcharm] == true && [charmtier] == 1000 + charmscore(item)",
 		// Switch - CTA
 		"[minimumsockets] >= 5 && [flag] == runeword # [plusskillbattleorders] >= 1 # [secondarytier] == 100000",
 		// Merc Armor - Fortitude
@@ -96,6 +91,45 @@ const finalBuild = {
 	stats: undefined,
 	autoEquipTiers: undefined,
 
+	charms: {
+		ResLife: {
+			max: 3,
+			have: [],
+			classid: sdk.items.SmallCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid && check.allRes === 5 && check.getStat(sdk.stats.MaxHp) === 20);
+			}
+		},
+
+		ResMf: {
+			max: 2,
+			have: [],
+			classid: sdk.items.SmallCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid && check.allRes === 5 && check.getStat(sdk.stats.MagicBonus) === 7);
+			}
+		},
+
+		ResFHR: {
+			max: 3,
+			have: [],
+			classid: sdk.items.SmallCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid && check.allRes === 5 && check.getStat(sdk.stats.FHR) === 5);
+			}
+		},
+
+		Skiller: {
+			max: 2,
+			have: [],
+			classid: sdk.items.GrandCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid && check.getStat(sdk.stats.AddSkillTab, sdk.skills.tabs.PalaCombat) === 1
+					&& check.getStat(sdk.stats.MaxHp) >= 40);
+			}
+		},
+	},
+	
 	AutoBuildTemplate: {
 		1:	{
 			Update: function () {

--- a/libs/SoloPlay/BuildFiles/paladin.HammershockBuild.js
+++ b/libs/SoloPlay/BuildFiles/paladin.HammershockBuild.js
@@ -76,10 +76,6 @@ const finalBuild = {
 		// Rings - Raven Frost && Bul-Kathos' Wedding Band
 		"[type] == ring && [quality] == unique # [dexterity] >= 15 && [tohit] >= 150 # [tier] == # [tier] == 100000",
 		"[type] == ring && [quality] == unique # [maxstamina] == 50 && [lifeleech] >= 3 # [tier] == 100000",
-		// Charms
-		"[name] == smallcharm && [quality] == magic # [fireresist]+[lightresist]+[coldresist]+[poisonresist] >= 20 && [maxhp] >= 20 # [invoquantity] == 6 && [finalcharm] == true && [charmtier] == 1000 + charmscore(item)",
-		"[name] == smallcharm && [quality] == magic # [fireresist]+[lightresist]+[coldresist]+[poisonresist] >= 20 && [itemmagicbonus] >= 7 # [invoquantity] == 2 && [finalcharm] == true && [charmtier] == 1000 + charmscore(item)",
-		"[name] == grandcharm && [quality] == magic # [offensiveaurasskilltab] == 1 # [invoquantity] == 2 && [finalcharm] == true && [charmtier] == 1000 + charmscore(item)",
 		// Switch - CTA
 		"[minimumsockets] >= 5 && [flag] == runeword # [plusskillbattleorders] >= 1 # [secondarytier] == 100000",
 		// Merc Final Armor - Fortitude
@@ -93,6 +89,36 @@ const finalBuild = {
 	],
 	stats: undefined,
 	autoEquipTiers: undefined,
+
+	charms: {
+		ResLife: {
+			max: 6,
+			have: [],
+			classid: sdk.items.SmallCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid && check.allRes === 5 && check.getStat(sdk.stats.MaxHp) === 20);
+			}
+		},
+
+		ResMf: {
+			max: 2,
+			have: [],
+			classid: sdk.items.SmallCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid && check.allRes === 5 && check.getStat(sdk.stats.MagicBonus) === 7);
+			}
+		},
+
+		Skiller: {
+			max: 2,
+			have: [],
+			classid: sdk.items.GrandCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid && check.getStat(sdk.stats.AddSkillTab, sdk.skills.tabs.Offensive) === 1
+					&& check.getStat(sdk.stats.MaxHp) >= 40);
+			}
+		},
+	},
 
 	AutoBuildTemplate: {
 		1:	{

--- a/libs/SoloPlay/BuildFiles/paladin.SancdreamerBuild.js
+++ b/libs/SoloPlay/BuildFiles/paladin.SancdreamerBuild.js
@@ -57,10 +57,6 @@ const finalBuild = {
 		// Rings - Raven Frost & Wisp
 		"[type] == ring && [quality] == unique # [dexterity] >= 15 && [tohit] >= 150 # [tier] == # [tier] == 100000",
 		"[type] == ring && [quality] == unique # [itemabsorblightpercent] >= 10 # [tier] == 100000",
-		// Charms
-		"[name] == smallcharm && [quality] == magic # [fireresist]+[lightresist]+[coldresist]+[poisonresist] >= 20 && [maxhp] >= 20 # [invoquantity] == 6 && [finalcharm] == true && [charmtier] == 1000 + charmscore(item)",
-		"[name] == smallcharm && [quality] == magic # [fireresist]+[lightresist]+[coldresist]+[poisonresist] >= 20 && [itemmagicbonus] >= 7 # [invoquantity] == 2 && [finalcharm] == true && [charmtier] == 1000 + charmscore(item)",
-		"[name] == grandcharm && [quality] == magic # [offensiveaurasskilltab] == 1 # [invoquantity] == 2 && [finalcharm] == true && [charmtier] == 1000 + charmscore(item)",
 		// Switch - CTA
 		"[minimumsockets] >= 5 && [flag] == runeword # [plusskillbattleorders] >= 1 # [secondarytier] == 100000",
 		// Merc Final Armor - Fortitude
@@ -73,6 +69,36 @@ const finalBuild = {
 		"[name] == demonhead && [quality] == unique && [flag] != ethereal # [strength] >= 25 && [enhanceddefense] >= 100 # [merctier] == 40000 + mercscore(item)",
 	],
 
+	charms: {
+		ResLife: {
+			max: 6,
+			have: [],
+			classid: sdk.items.SmallCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid && check.allRes === 5 && check.getStat(sdk.stats.MaxHp) === 20);
+			}
+		},
+
+		ResMf: {
+			max: 2,
+			have: [],
+			classid: sdk.items.SmallCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid && check.allRes === 5 && check.getStat(sdk.stats.MagicBonus) === 7);
+			}
+		},
+
+		Skiller: {
+			max: 2,
+			have: [],
+			classid: sdk.items.GrandCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid && check.getStat(sdk.stats.AddSkillTab, sdk.skills.tabs.Offensive) === 1
+					&& check.getStat(sdk.stats.MaxHp) >= 40);
+			}
+		},
+	},
+
 	AutoBuildTemplate: {
 		1:	{
 			Update: function () {
@@ -81,7 +107,6 @@ const finalBuild = {
 				Config.LowManaSkill = [-1, -1];
 
 				Config.SkipImmune = ["lightning and magic and physical"];	// Don't think this ever happens but should skip if it does
-
 				Config.BeltColumn = ["hp", "hp", "mp", "rv"];
 			}
 		},

--- a/libs/SoloPlay/BuildFiles/paladin.SmiterBuild.js
+++ b/libs/SoloPlay/BuildFiles/paladin.SmiterBuild.js
@@ -49,17 +49,13 @@ const finalBuild = {
 		// Gloves - Drac's
 		"[name] == vampirebonegloves && [quality] == unique && [flag] != ethereal # [enhanceddefense] >= 100 && [strength] >= 12 && [lifeleech] >= 9 # [tier] == 100000 + tierscore(item)",
 		// Amulet - Highlords
-		"[type] == amulet && [quality] == unique # [lightresist] == 35 # [tier] == 100000", 
+		"[type] == amulet && [quality] == unique # [lightresist] == 35 # [tier] == 100000",
 		// Final Rings - Perfect Raven Frost & Bul-Kathos' Wedding Band
 		"[type] == ring && [quality] == unique # [dexterity] == 20 && [tohit] == 250 # [tier] == # [tier] == 110000",
 		"[type] == ring && [quality] == unique # [maxstamina] == 50 && [lifeleech] == 5 # [tier] == 110000",
 		// Rings - Raven Frost && Bul-Kathos' Wedding Band
 		"[type] == ring && [quality] == unique # [dexterity] >= 15 && [tohit] >= 150 # [tier] == # [tier] == 100000",
 		"[type] == ring && [quality] == unique # [maxstamina] == 50 && [lifeleech] >= 3 # [tier] == 100000",
-		// Charms
-		"[name] == smallcharm && [quality] == magic # [fireresist]+[lightresist]+[coldresist]+[poisonresist] >= 20 && [maxhp] >= 20 # [invoquantity] == 4 && [finalcharm] == true && [charmtier] == 1000 + charmscore(item)",
-		"[name] == smallcharm && [quality] == magic # [fireresist]+[lightresist]+[coldresist]+[poisonresist] >= 20 && [fhr] >= 5 # [invoquantity] == 4 && [finalcharm] == true && [charmtier] == 1000 + charmscore(item)",
-		"[name] == grandcharm && [quality] == magic # [palicombatskilltab] == 1 # [invoquantity] == 2 && [finalcharm] == true && [charmtier] == 1000 + charmscore(item)",
 		// Switch - CTA
 		"[minimumsockets] >= 5 && [flag] == runeword # [plusskillbattleorders] >= 1 # [secondarytier] == 100000",
 		// Merc Final Armor - Fortitude
@@ -69,6 +65,36 @@ const finalBuild = {
 		// Merc Helmet - Andy's
 		"[name] == demonhead && [quality] == unique && [flag] != ethereal # [strength] >= 25 && [enhanceddefense] >= 100 # [merctier] == 40000 + mercscore(item)",
 	],
+
+	charms: {
+		ResLife: {
+			max: 6,
+			have: [],
+			classid: sdk.items.SmallCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid && check.allRes === 5 && check.getStat(sdk.stats.MaxHp) === 20);
+			}
+		},
+
+		ResMf: {
+			max: 2,
+			have: [],
+			classid: sdk.items.SmallCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid && check.allRes === 5 && check.getStat(sdk.stats.MagicBonus) === 7);
+			}
+		},
+
+		Skiller: {
+			max: 2,
+			have: [],
+			classid: sdk.items.GrandCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid && check.getStat(sdk.stats.AddSkillTab, sdk.skills.tabs.PalaCombat) === 1
+					&& check.getStat(sdk.stats.MaxHp) >= 40);
+			}
+		},
+	},
 
 	AutoBuildTemplate: {
 		1:	{

--- a/libs/SoloPlay/BuildFiles/paladin.TorchadinBuild.js
+++ b/libs/SoloPlay/BuildFiles/paladin.TorchadinBuild.js
@@ -58,10 +58,6 @@ const finalBuild = {
 		// Rings - Raven Frost && Bul-Kathos' Wedding Band
 		"[type] == ring && [quality] == unique # [dexterity] >= 15 && [tohit] >= 150 # [tier] == # [tier] == 100000",
 		"[type] == ring && [quality] == unique # [maxstamina] == 50 && [lifeleech] >= 3 # [tier] == 100000",
-		// Charms
-		"[name] == smallcharm && [quality] == magic # [fireresist]+[lightresist]+[coldresist]+[poisonresist] >= 20 && [maxhp] >= 20 # [invoquantity] == 6 && [finalcharm] == true && [charmtier] == 1000 + charmscore(item)",
-		"[name] == smallcharm && [quality] == magic # [fireresist]+[lightresist]+[coldresist]+[poisonresist] >= 20 && [itemmagicbonus] >= 7 # [invoquantity] == 2 && [finalcharm] == true && [charmtier] == 1000 + charmscore(item)",
-		"[name] == grandcharm && [quality] == magic # [offensiveaurasskilltab] == 1 # [invoquantity] == 2 && [finalcharm] == true && [charmtier] == 1000 + charmscore(item)",
 		// Switch - CTA
 		"[minimumsockets] >= 5 && [flag] == runeword # [plusskillbattleorders] >= 1 # [secondarytier] == 100000",
 		// Merc Final Armor - Fortitude
@@ -73,6 +69,36 @@ const finalBuild = {
 		// Merc Helmet - Andy's
 		"[name] == demonhead && [quality] == unique && [flag] != ethereal # [strength] >= 25 && [enhanceddefense] >= 100 # [merctier] == 40000 + mercscore(item)",
 	],
+
+	charms: {
+		ResLife: {
+			max: 6,
+			have: [],
+			classid: sdk.items.SmallCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid && check.allRes === 5 && check.getStat(sdk.stats.MaxHp) === 20);
+			}
+		},
+
+		ResMf: {
+			max: 2,
+			have: [],
+			classid: sdk.items.SmallCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid && check.allRes === 5 && check.getStat(sdk.stats.MagicBonus) === 7);
+			}
+		},
+
+		Skiller: {
+			max: 2,
+			have: [],
+			classid: sdk.items.GrandCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid && check.getStat(sdk.stats.AddSkillTab, sdk.skills.tabs.Offensive) === 1
+					&& check.getStat(sdk.stats.MaxHp) >= 40);
+			}
+		},
+	},
 
 	AutoBuildTemplate: {
 		1:	{

--- a/libs/SoloPlay/BuildFiles/paladin.ZealerBuild.js
+++ b/libs/SoloPlay/BuildFiles/paladin.ZealerBuild.js
@@ -32,7 +32,7 @@ const finalBuild = {
 	],
 	autoEquipTiers: [ // autoequip final gear
 		// Weapon - Grief
-		"[type] == sword && [flag] == runeword # [ias] >= 30 # [tier] == 100000", 
+		"[type] == sword && [flag] == runeword # [ias] >= 30 # [tier] == 100000",
 		// Final Helm - Upp'ed Vamp Gaze
 		"[name] == bonevisage && [quality] == unique && [flag] != ethereal # [enhanceddefense] >= 100 && [lifeleech] >= 6 # [tier] == 100000 + tierscore(item)",
 		// Helm -Vamp Gaze
@@ -72,6 +72,36 @@ const finalBuild = {
 		// Merc Helmet - Andy's
 		"[name] == demonhead && [quality] == unique && [flag] != ethereal # [strength] >= 25 && [enhanceddefense] >= 100 # [merctier] == 40000 + mercscore(item)",
 	],
+
+	charms: {
+		ResLife: {
+			max: 6,
+			have: [],
+			classid: sdk.items.SmallCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid && check.allRes === 5 && check.getStat(sdk.stats.MaxHp) === 20);
+			}
+		},
+
+		ResMf: {
+			max: 2,
+			have: [],
+			classid: sdk.items.SmallCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid && check.allRes === 5 && check.getStat(sdk.stats.MagicBonus) === 7);
+			}
+		},
+
+		Skiller: {
+			max: 2,
+			have: [],
+			classid: sdk.items.GrandCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid && check.getStat(sdk.stats.AddSkillTab, sdk.skills.tabs.PalaCombat) === 1
+					&& check.getStat(sdk.stats.MaxHp) >= 40);
+			}
+		},
+	},
 
 	AutoBuildTemplate: {
 		1:	{

--- a/libs/SoloPlay/BuildFiles/sorceress.BlizzballerBuild.js
+++ b/libs/SoloPlay/BuildFiles/sorceress.BlizzballerBuild.js
@@ -77,12 +77,6 @@ const finalBuild = {
 		"[type] == ring && [quality] == unique # [itemmagicbonus] == 30 # [tier] == 100000",
 		// Rings - Raven Frost
 		"[type] == ring && [quality] == unique # [dexterity] >= 15 # [tier] == 90000",
-		// Charms
-		"[name] == smallcharm && [quality] == magic # [fireresist]+[lightresist]+[coldresist]+[poisonresist] >= 20 && [maxhp] >= 20 # [invoquantity] == 3 && [finalcharm] == true && [charmtier] == 1000 + charmscore(item)",
-		"[name] == smallcharm && [quality] == magic # [fireresist]+[lightresist]+[coldresist]+[poisonresist] >= 20 && [itemmagicbonus] >= 7 # [invoquantity] == 3 && [finalcharm] == true && [charmtier] == 1000 + charmscore(item)",
-		"[name] == smallcharm && [quality] == magic # [fireresist]+[lightresist]+[coldresist]+[poisonresist] >= 20 && [fhr] >= 5 # [invoquantity] == 1 && [finalcharm] == true && [charmtier] == 1000 + charmscore(item)",
-		"[name] == grandcharm && [quality] == magic # [coldskilltab] == 1 # [invoquantity] == 1 && [finalcharm] == true && [charmtier] == 1000 + charmscore(item)",
-		"[name] == grandcharm && [quality] == magic # [fireskilltab] == 1 # [invoquantity] == 1 && [finalcharm] == true && [charmtier] == 1000 + charmscore(item)",
 		// Switch - CTA
 		"[minimumsockets] >= 5 && [flag] == runeword # [plusskillbattleorders] >= 1 # [secondarytier] == 100000",
 		// Switch Shield - 1+ all skill
@@ -94,6 +88,55 @@ const finalBuild = {
 		// Merc Helmet - Andy's
 		"[name] == demonhead && [quality] == unique && [flag] != ethereal # [strength] >= 25 && [enhanceddefense] >= 100 # [merctier] == 40000 + mercscore(item)",
 	],
+
+	charms: {
+		ResLife: {
+			max: 3,
+			have: [],
+			classid: sdk.items.SmallCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid && check.allRes === 5 && check.getStat(sdk.stats.MaxHp) === 20);
+			}
+		},
+
+		ResMf: {
+			max: 2,
+			have: [],
+			classid: sdk.items.SmallCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid && check.allRes === 5 && check.getStat(sdk.stats.MagicBonus) === 7);
+			}
+		},
+
+		ResFHR: {
+			max: 3,
+			have: [],
+			classid: sdk.items.SmallCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid && check.allRes === 5 && check.getStat(sdk.stats.FHR) === 5);
+			}
+		},
+
+		SkillerFire: {
+			max: 1,
+			have: [],
+			classid: sdk.items.GrandCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid && check.getStat(sdk.stats.AddSkillTab, sdk.skills.tabs.Fire) === 1
+					&& check.getStat(sdk.stats.MaxHp) >= 40);
+			}
+		},
+
+		SkillerCold: {
+			max: 1,
+			have: [],
+			classid: sdk.items.GrandCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid && check.getStat(sdk.stats.AddSkillTab, sdk.skills.tabs.Cold) === 1
+					&& check.getStat(sdk.stats.MaxHp) >= 40);
+			}
+		},
+	},
 
 	AutoBuildTemplate: {
 		1:	{

--- a/libs/SoloPlay/BuildFiles/sorceress.BlovaBuild.js
+++ b/libs/SoloPlay/BuildFiles/sorceress.BlovaBuild.js
@@ -66,13 +66,6 @@ const finalBuild = {
 		"[name] == ring && [quality] == unique # [maxstamina] == 50 && [lifeleech] == 5 # [tier] == 100000",
 		// Ring - Bul-Kathos' Wedding Band
 		"[name] == ring && [quality] == unique # [maxstamina] == 50 && [lifeleech] >= 3 # [tier] == 90000",
-		// Charms
-		"[name] == smallcharm && [quality] == magic # [fireresist]+[lightresist]+[coldresist]+[poisonresist] >= 20 && [maxhp] >= 20 # [invoquantity] == 3 && [finalcharm] == true && [charmtier] == 1000 + charmscore(item)",
-		"[name] == smallcharm && [quality] == magic # [fireresist]+[lightresist]+[coldresist]+[poisonresist] >= 20 && [itemmagicbonus] >= 7 # [invoquantity] == 2 && [finalcharm] == true && [charmtier] == 1000 + charmscore(item)",
-		"[name] == smallcharm && [quality] == magic # [fireresist]+[lightresist]+[coldresist]+[poisonresist] >= 20 && [fhr] >= 5 # [invoquantity] == 1 && [finalcharm] == true && [charmtier] == 1000 + charmscore(item)",
-		"[name] == smallcharm && [quality] == magic # [maxhp] == 20 && [maxmana] == 17 # [invoquantity] == 2 && [finalcharm] == true && [charmtier] == 1000 + charmscore(item)",
-		"[name] == grandcharm && [quality] == magic # [coldskilltab] == 1 # [invoquantity] == 1 && [finalcharm] == true && [charmtier] == 1000 + charmscore(item)",
-		"[name] == grandcharm && [quality] == magic # [lightningskilltab] == 1 # [invoquantity] == 1 && [finalcharm] == true && [charmtier] == 1000 + charmscore(item)",
 		// Switch - CTA
 		"[minimumsockets] >= 5 && [flag] == runeword # [plusskillbattleorders] >= 1 # [secondarytier] == 100000",
 		// Switch Final Shield - Spirit
@@ -86,6 +79,55 @@ const finalBuild = {
 		// Merc Helmet - Andy's
 		"[name] == demonhead && [quality] == unique && [flag] != ethereal # [strength] >= 25 && [enhanceddefense] >= 100 # [merctier] == 40000 + mercscore(item)",
 	],
+
+	charms: {
+		ResLife: {
+			max: 3,
+			have: [],
+			classid: sdk.items.SmallCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid && check.allRes === 5 && check.getStat(sdk.stats.MaxHp) === 20);
+			}
+		},
+
+		ResMf: {
+			max: 2,
+			have: [],
+			classid: sdk.items.SmallCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid && check.allRes === 5 && check.getStat(sdk.stats.MagicBonus) === 7);
+			}
+		},
+
+		ResFHR: {
+			max: 3,
+			have: [],
+			classid: sdk.items.SmallCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid && check.allRes === 5 && check.getStat(sdk.stats.FHR) === 5);
+			}
+		},
+
+		SkillerLight: {
+			max: 1,
+			have: [],
+			classid: sdk.items.GrandCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid && check.getStat(sdk.stats.AddSkillTab, sdk.skills.tabs.Lightning) === 1
+					&& check.getStat(sdk.stats.MaxHp) >= 40);
+			}
+		},
+
+		SkillerCold: {
+			max: 1,
+			have: [],
+			classid: sdk.items.GrandCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid && check.getStat(sdk.stats.AddSkillTab, sdk.skills.tabs.Cold) === 1
+					&& check.getStat(sdk.stats.MaxHp) >= 40);
+			}
+		},
+	},
 
 	AutoBuildTemplate: {
 		1:	{

--- a/libs/SoloPlay/BuildFiles/sorceress.ColdBuild.js
+++ b/libs/SoloPlay/BuildFiles/sorceress.ColdBuild.js
@@ -67,11 +67,6 @@ const finalBuild = {
 		"[type] == ring && [quality] == unique # [itemmagicbonus] == 30 # [tier] == 100000",
 		// Rings - Raven Frost
 		"[type] == ring && [quality] == unique # [dexterity] >= 15 # [tier] == 90000",
-		// Charms
-		"[name] == smallcharm && [quality] == magic # [fireresist]+[lightresist]+[coldresist]+[poisonresist] >= 20 && [maxhp] >= 20 # [invoquantity] == 3 && [finalcharm] == true && [charmtier] == 1000 + charmscore(item)",
-		"[name] == smallcharm && [quality] == magic # [fireresist]+[lightresist]+[coldresist]+[poisonresist] >= 20 && [itemmagicbonus] >= 7 # [invoquantity] == 3 && [finalcharm] == true && [charmtier] == 1000 + charmscore(item)",
-		"[name] == smallcharm && [quality] == magic # [fireresist]+[lightresist]+[coldresist]+[poisonresist] >= 20 && [fhr] >= 5 # [invoquantity] == 1 && [finalcharm] == true && [charmtier] == 1000 + charmscore(item)",
-		"[name] == grandcharm && [quality] == magic # [coldskilltab] == 1 # [invoquantity] == 2 && [finalcharm] == true && [charmtier] == 1000 + charmscore(item)",
 		// Switch - CTA
 		"[minimumsockets] >= 5 && [flag] == runeword # [plusskillbattleorders] >= 1 # [secondarytier] == 100000",
 		// Switch Shield - 1+ all skill
@@ -83,6 +78,45 @@ const finalBuild = {
 		// Merc Helmet - Andy's
 		"[name] == demonhead && [quality] == unique && [flag] != ethereal # [strength] >= 25 && [enhanceddefense] >= 100 # [merctier] == 40000 + mercscore(item)",
 	],
+
+	charms: {
+		ResLife: {
+			max: 3,
+			have: [],
+			classid: sdk.items.SmallCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid && check.allRes === 5 && check.getStat(sdk.stats.MaxHp) === 20);
+			}
+		},
+
+		ResMf: {
+			max: 3,
+			have: [],
+			classid: sdk.items.SmallCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid && check.allRes === 5 && check.getStat(sdk.stats.MagicBonus) === 7);
+			}
+		},
+
+		ResFHR: {
+			max: 1,
+			have: [],
+			classid: sdk.items.SmallCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid && check.allRes === 5 && check.getStat(sdk.stats.FHR) === 5);
+			}
+		},
+
+		Skiller: {
+			max: 2,
+			have: [],
+			classid: sdk.items.GrandCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid && check.getStat(sdk.stats.AddSkillTab, sdk.skills.tabs.Cold) === 1
+					&& check.getStat(sdk.stats.MaxHp) >= 40);
+			}
+		},
+	},
 
 	AutoBuildTemplate: {
 		1:	{

--- a/libs/SoloPlay/BuildFiles/sorceress.EsorbBuild.js
+++ b/libs/SoloPlay/BuildFiles/sorceress.EsorbBuild.js
@@ -82,12 +82,6 @@ const finalBuild = {
 		"[type] == ring && [quality] == unique # [itemmagicbonus] == 30 # [tier] == 100000",
 		// Rings - Raven Frost
 		"[type] == ring && [quality] == unique # [dexterity] >= 15 # [tier] == 90000",
-		// Charms
-		"[name] == smallcharm && [quality] == magic # [fireresist]+[lightresist]+[coldresist]+[poisonresist] >= 20 && [maxhp] >= 20 # [invoquantity] == 3 && [finalcharm] == true && [charmtier] == 1000 + charmscore(item)",
-		"[name] == smallcharm && [quality] == magic # [fireresist]+[lightresist]+[coldresist]+[poisonresist] >= 20 && [itemmagicbonus] >= 7 # [invoquantity] == 3 && [finalcharm] == true && [charmtier] == 1000 + charmscore(item)",
-		"[name] == smallcharm && [quality] == magic # [fireresist]+[lightresist]+[coldresist]+[poisonresist] >= 20 && [fhr] >= 5 # [invoquantity] == 1 && [finalcharm] == true && [charmtier] == 1000 + charmscore(item)",
-		"[name] == grandcharm && [quality] == magic # [coldskilltab] == 1 # [invoquantity] == 1 && [finalcharm] == true && [charmtier] == 1000 + charmscore(item)",
-		"[name] == grandcharm && [quality] == magic # [fireskilltab] == 1 # [invoquantity] == 1 && [finalcharm] == true && [charmtier] == 1000 + charmscore(item)",
 		// Switch - CTA
 		"[minimumsockets] >= 5 && [flag] == runeword # [plusskillbattleorders] >= 1 # [secondarytier] == 100000",
 		// Switch Shield - 1+ all skill
@@ -102,6 +96,55 @@ const finalBuild = {
 	stats: undefined,
 	autoEquipTiers: undefined,
 
+	charms: {
+		ResLife: {
+			max: 3,
+			have: [],
+			classid: sdk.items.SmallCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid && check.allRes === 5 && check.getStat(sdk.stats.MaxHp) === 20);
+			}
+		},
+
+		ResMf: {
+			max: 2,
+			have: [],
+			classid: sdk.items.SmallCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid && check.allRes === 5 && check.getStat(sdk.stats.MagicBonus) === 7);
+			}
+		},
+
+		ResFHR: {
+			max: 3,
+			have: [],
+			classid: sdk.items.SmallCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid && check.allRes === 5 && check.getStat(sdk.stats.FHR) === 5);
+			}
+		},
+
+		SkillerLight: {
+			max: 1,
+			have: [],
+			classid: sdk.items.GrandCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid && check.getStat(sdk.stats.AddSkillTab, sdk.skills.tabs.Lightning) === 1
+					&& check.getStat(sdk.stats.MaxHp) >= 40);
+			}
+		},
+
+		SkillerCold: {
+			max: 1,
+			have: [],
+			classid: sdk.items.GrandCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid && check.getStat(sdk.stats.AddSkillTab, sdk.skills.tabs.Cold) === 1
+					&& check.getStat(sdk.stats.MaxHp) >= 40);
+			}
+		},
+	},
+	
 	AutoBuildTemplate: {
 		1:	{
 			Update: function () {

--- a/libs/SoloPlay/BuildFiles/sorceress.LightningBuild.js
+++ b/libs/SoloPlay/BuildFiles/sorceress.LightningBuild.js
@@ -81,6 +81,54 @@ const finalBuild = {
 		"[name] == demonhead && [quality] == unique && [flag] != ethereal # [strength] >= 25 && [enhanceddefense] >= 100 # [merctier] == 40000 + mercscore(item)",
 	],
 
+	charms: {
+		ResLife: {
+			max: 3,
+			have: [],
+			classid: sdk.items.SmallCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid && check.allRes === 5 && check.getStat(sdk.stats.MaxHp) === 20);
+			}
+		},
+
+		ResMf: {
+			max: 2,
+			have: [],
+			classid: sdk.items.SmallCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid && check.allRes === 5 && check.getStat(sdk.stats.MagicBonus) === 7);
+			}
+		},
+
+		ResFHR: {
+			max: 1,
+			have: [],
+			classid: sdk.items.SmallCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid && check.allRes === 5 && check.getStat(sdk.stats.FHR) === 5);
+			}
+		},
+
+		LifeMana: {
+			max: 2,
+			have: [],
+			classid: sdk.items.SmallCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid && check.getStat(sdk.stats.MaxHp) === 20 && check.getStat(sdk.stats.MaxMana) === 17);
+			}
+		},
+
+		Skiller: {
+			max: 2,
+			have: [],
+			classid: sdk.items.GrandCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid && check.getStat(sdk.stats.AddSkillTab, sdk.skills.tabs.Lightning) === 1
+					&& check.getStat(sdk.stats.MaxHp) >= 40);
+			}
+		},
+	},
+
 	AutoBuildTemplate: {
 		1:	{
 			Update: function () {

--- a/libs/SoloPlay/BuildFiles/sorceress.MeteorbBuild.js
+++ b/libs/SoloPlay/BuildFiles/sorceress.MeteorbBuild.js
@@ -88,12 +88,6 @@ const finalBuild = {
 		"[type] == ring && [quality] == unique # [itemmagicbonus] >= 30 # [tier] == 100000",
 		// Rings - Raven Frost
 		"[type] == ring && [quality] == unique # [dexterity] >= 15 # [tier] == 100000",
-		// Charms
-		"[name] == smallcharm && [quality] == magic # [fireresist]+[lightresist]+[coldresist]+[poisonresist] >= 20 && [maxhp] >= 20 # [invoquantity] == 3 && [finalcharm] == true && [charmtier] == 1000 + charmscore(item)",
-		"[name] == smallcharm && [quality] == magic # [fireresist]+[lightresist]+[coldresist]+[poisonresist] >= 20 && [itemmagicbonus] >= 7 # [invoquantity] == 3 && [finalcharm] == true && [charmtier] == 1000 + charmscore(item)",
-		"[name] == smallcharm && [quality] == magic # [fireresist]+[lightresist]+[coldresist]+[poisonresist] >= 20 && [fhr] >= 5 # [invoquantity] == 1 && [finalcharm] == true && [charmtier] == 1000 + charmscore(item)",
-		"[name] == grandcharm && [quality] == magic # [coldskilltab] == 1 # [invoquantity] == 1 && [finalcharm] == true && [charmtier] == 1000 + charmscore(item)",
-		"[name] == grandcharm && [quality] == magic # [fireskilltab] == 1 # [invoquantity] == 1 && [finalcharm] == true && [charmtier] == 1000 + charmscore(item)",
 		// Switch - CTA
 		"[minimumsockets] >= 5 && [flag] == runeword # [plusskillbattleorders] >= 1 # [secondarytier] == 100000",
 		// Switch Shield - 1+ all skill
@@ -108,6 +102,55 @@ const finalBuild = {
 	stats: undefined,
 	autoEquipTiers: undefined,
 
+	charms: {
+		ResLife: {
+			max: 3,
+			have: [],
+			classid: sdk.items.SmallCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid && check.allRes === 5 && check.getStat(sdk.stats.MaxHp) === 20);
+			}
+		},
+
+		ResMf: {
+			max: 2,
+			have: [],
+			classid: sdk.items.SmallCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid && check.allRes === 5 && check.getStat(sdk.stats.MagicBonus) === 7);
+			}
+		},
+
+		ResFHR: {
+			max: 3,
+			have: [],
+			classid: sdk.items.SmallCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid && check.allRes === 5 && check.getStat(sdk.stats.FHR) === 5);
+			}
+		},
+
+		SkillerFire: {
+			max: 1,
+			have: [],
+			classid: sdk.items.GrandCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid && check.getStat(sdk.stats.AddSkillTab, sdk.skills.tabs.Fire) === 1
+					&& check.getStat(sdk.stats.MaxHp) >= 40);
+			}
+		},
+
+		SkillerCold: {
+			max: 1,
+			have: [],
+			classid: sdk.items.GrandCharm,
+			stats: function (check) {
+				return (!check.unique && check.classid === this.classid && check.getStat(sdk.stats.AddSkillTab, sdk.skills.tabs.Cold) === 1
+					&& check.getStat(sdk.stats.MaxHp) >= 40);
+			}
+		},
+	},
+	
 	AutoBuildTemplate: {
 		1:	{
 			Update: function () {

--- a/libs/SoloPlay/Config/Amazon.js
+++ b/libs/SoloPlay/Config/Amazon.js
@@ -111,6 +111,7 @@ function LoadConfig () {
 		"[type] == wand && [quality] >= normal # [itemchargedskill] == 91 # [secondarytier] == 50000 + chargeditemscore(item, 91)",	// Lower Resist charged wand
 		// Charms
 		"[name] == smallcharm && [quality] == magic # # [invoquantity] == 8 && [charmtier] == charmscore(item)",
+		"[name] == grandcharm && [quality] == magic # # [invoquantity] == 2 && [charmtier] == charmscore(item)",
 		// Special Charms
 		"[name] == smallcharm && [quality] == unique # [itemallskills] == 1 # [charmtier] == 100000",
 		"[name] == largecharm && [quality] == unique # [itemaddclassskills] == 3 # [charmtier] == 100000",

--- a/libs/SoloPlay/Config/Assassin.js
+++ b/libs/SoloPlay/Config/Assassin.js
@@ -112,6 +112,7 @@ function LoadConfig () {
 		"[name] == smallcharm && [quality] == magic # [maxhp] >= 1 # [invoquantity] == 2 && [charmtier] == charmscore(item)",
 		"[name] == smallcharm && [quality] == magic # [itemmagicbonus] >= 1 # [invoquantity] == 2 && [charmtier] == charmscore(item)",
 		"[name] == smallcharm && [quality] == magic # # [invoquantity] == 2 && [charmtier] == charmscore(item)",
+		"[name] == grandcharm && [quality] == magic # # [invoquantity] == 2 && [charmtier] == charmscore(item)",
 		// Special Charms
 		"[name] == smallcharm && [quality] == unique # [itemallskills] == 1 # [charmtier] == 100000",
 		"[name] == largecharm && [quality] == unique # [itemaddclassskills] == 3 # [charmtier] == 100000",
@@ -137,7 +138,7 @@ function LoadConfig () {
 	Config.AttackSkill = [0, 0, 0, 0, 0, 0, 0];
 	Config.LowManaSkill = [0, 0];
 	Config.MaxAttackCount = 1000;
-	Config.BossPriority = me.normal ? true : false;
+	Config.BossPriority = me.normal;
 	Config.ClearType = 0;
 	Config.ClearPath = {Range: (Pather.canTeleport() ? 30 : 20), Spectype: 0};
 

--- a/libs/SoloPlay/Config/Barbarian.js
+++ b/libs/SoloPlay/Config/Barbarian.js
@@ -109,6 +109,7 @@ function LoadConfig () {
 	let expansionTiers = [
 		// Charms
 		"[name] == smallcharm && [quality] == magic # # [invoquantity] == 8 && [charmtier] == charmscore(item)",
+		"[name] == grandcharm && [quality] == magic # # [invoquantity] == 2 && [charmtier] == charmscore(item)",
 		// Special Charms
 		"[name] == smallcharm && [quality] == unique # [itemallskills] == 1 # [charmtier] == 100000",
 		"[name] == largecharm && [quality] == unique # [itemaddclassskills] == 3 # [charmtier] == 100000",
@@ -129,7 +130,7 @@ function LoadConfig () {
 	Config.AttackSkill = [-1, 0, 0, 0, 0];
 	Config.LowManaSkill = me.getSkill(sdk.skills.DoubleSwing, 1) >= 9 ? [sdk.skills.DoubleSwing, 0] : [0, -1];
 	Config.MaxAttackCount = 1000;
-	Config.BossPriority = me.normal ? true : false;
+	Config.BossPriority = me.normal;
 	Config.ClearType = 0;
 	Config.ClearPath = {Range: (Pather.canTeleport() ? 30 : 10), Spectype: 0};
 

--- a/libs/SoloPlay/Config/Druid.js
+++ b/libs/SoloPlay/Config/Druid.js
@@ -112,6 +112,7 @@ function LoadConfig () {
 		"[name] == smallcharm && [quality] == magic # [maxhp] >= 1 # [invoquantity] == 2 && [charmtier] == charmscore(item)",
 		"[name] == smallcharm && [quality] == magic # [itemmagicbonus] >= 1 # [invoquantity] == 2 && [charmtier] == charmscore(item)",
 		"[name] == smallcharm && [quality] == magic # # [invoquantity] == 2 && [charmtier] == charmscore(item)",
+		"[name] == grandcharm && [quality] == magic # # [invoquantity] == 2 && [charmtier] == charmscore(item)",
 		// Special Charms
 		"[name] == smallcharm && [quality] == unique # [itemallskills] == 1 # [charmtier] == 100000",
 		"[name] == largecharm && [quality] == unique # [itemaddclassskills] == 3 # [charmtier] == 100000",
@@ -143,7 +144,7 @@ function LoadConfig () {
 	Config.AttackSkill = [0, 0, 0, 0, 0, 0, 0];
 	Config.LowManaSkill = [0, 0];
 	Config.MaxAttackCount = 1000;
-	Config.BossPriority = me.normal ? true : false;
+	Config.BossPriority = me.normal;
 	Config.ClearType = 0;
 	Config.ClearPath = {Range: (Pather.canTeleport() ? 30 : 10), Spectype: 0};
 

--- a/libs/SoloPlay/Config/Necromancer.js
+++ b/libs/SoloPlay/Config/Necromancer.js
@@ -114,6 +114,7 @@ function LoadConfig () {
 		"[name] == smallcharm && [quality] == magic # [maxhp] >= 1 # [invoquantity] == 2 && [charmtier] == charmscore(item)",
 		"[name] == smallcharm && [quality] == magic # [itemmagicbonus] >= 1 # [invoquantity] == 2 && [charmtier] == charmscore(item)",
 		"[name] == smallcharm && [quality] == magic # [fireresist]+[lightresist]+[coldresist]+[poisonresist] >= 1 # [invoquantity] == 2 && [charmtier] == charmscore(item)",
+		"[name] == grandcharm && [quality] == magic # # [invoquantity] == 2 && [charmtier] == charmscore(item)",
 		// Special Charms
 		"[name] == smallcharm && [quality] == unique # [itemallskills] == 1 # [charmtier] == 100000",
 		"[name] == largecharm && [quality] == unique # [itemaddclassskills] == 3 # [charmtier] == 100000",
@@ -135,7 +136,7 @@ function LoadConfig () {
 	Config.AttackSkill = [0, 0, 0, 0, 0, 0, 0];
 	Config.LowManaSkill = [0, 0];
 	Config.MaxAttackCount = 1000;
-	Config.BossPriority = me.normal ? true : false;
+	Config.BossPriority = me.normal;
 	Config.ClearType = 0;
 	Config.ClearPath = {Range: (Pather.canTeleport() ? 30 : 20), Spectype: 0};
 
@@ -151,10 +152,6 @@ function LoadConfig () {
 	Config.Dodge = Check.haveItem("armor", "runeword", "Enigma");
 	Config.DodgeRange = Check.haveItem("armor", "runeword", "Enigma") ? 10 : 5;
 	Config.DodgeHP = 90; // Dodge only if HP percent is less than or equal to Config.DodgeHP. 100 = always dodge.
-
-	/* Curses. */
-	Config.Curse[0] = -1; // Boss curse.
-	Config.Curse[1] = -1; // Other monsters curse.
 
 	/* Summons. */
 	Config.ReviveUnstackable = true;

--- a/libs/SoloPlay/Config/Paladin.js
+++ b/libs/SoloPlay/Config/Paladin.js
@@ -125,6 +125,7 @@ function LoadConfig () {
 		"[name] == smallcharm && [quality] == magic # [maxhp] >= 1 # [invoquantity] == 2 && [charmtier] == charmscore(item)",
 		"[name] == smallcharm && [quality] == magic # [itemmagicbonus] >= 1 # [invoquantity] == 2 && [charmtier] == charmscore(item)",
 		"[name] == smallcharm && [quality] == magic # # [invoquantity] == 2 && [charmtier] == charmscore(item)",
+		"[name] == grandcharm && [quality] == magic # # [invoquantity] == 2 && [charmtier] == charmscore(item)",
 		// Special Charms
 		"[name] == smallcharm && [quality] == unique # [itemallskills] == 1 # [charmtier] == 100000",
 		"[name] == largecharm && [quality] == unique # [itemaddclassskills] == 3 # [charmtier] == 100000",
@@ -145,7 +146,7 @@ function LoadConfig () {
 	Config.AttackSkill = [0, 0, 0, 0, 0, 0, 0];
 	Config.LowManaSkill = [0, 0];
 	Config.MaxAttackCount = 1000;
-	Config.BossPriority = me.normal ? true : false;
+	Config.BossPriority = me.normal;
 	Config.ClearType = 0;
 	Config.ClearPath = {Range: (Pather.canTeleport() ? 30 : 10), Spectype: 0};
 
@@ -372,7 +373,7 @@ function LoadConfig () {
 
 			if ((me.ladder || Developer.addLadderRW) && Item.getEquippedItemMerc(3).prefixnum !== sdk.locale.items.Fortitude
 				&& me.haveAll([{name: sdk.locale.items.HandofJustice}, {name: sdk.locale.items.Dragon, itemtype: sdk.itemtype.Armor},
-				{name: sdk.locale.items.Dream, itemtype: sdk.itemtype.AuricShields}, {name: sdk.locale.items.Dream, itemtype: sdk.itemtype.Helm}])) {
+					{name: sdk.locale.items.Dream, itemtype: sdk.itemtype.AuricShields}, {name: sdk.locale.items.Dream, itemtype: sdk.itemtype.Helm}])) {
 				if (!isIncluded("SoloPlay/BuildFiles/Runewords/MercFortitude.js")) {
 					include("SoloPlay/BuildFiles/Runewords/MercFortitude.js");
 				}

--- a/libs/SoloPlay/Config/Sorceress.js
+++ b/libs/SoloPlay/Config/Sorceress.js
@@ -122,6 +122,7 @@ function LoadConfig () {
 		"[name] == smallcharm && [quality] == magic # [maxhp] >= 1 # [invoquantity] == 2 && [charmtier] == charmscore(item)",
 		"[name] == smallcharm && [quality] == magic # [itemmagicbonus] >= 1 # [invoquantity] == 2 && [charmtier] == charmscore(item)",
 		"[name] == smallcharm && [quality] == magic # [fireresist]+[lightresist]+[coldresist]+[poisonresist] >= 1 # [invoquantity] == 2 && [charmtier] == charmscore(item)",
+		"[name] == grandcharm && [quality] == magic # # [invoquantity] == 2 && [charmtier] == charmscore(item)",
 		// Special Charms
 		"[name] == smallcharm && [quality] == unique # [itemallskills] == 1 # [charmtier] == 100000",
 		"[name] == largecharm && [quality] == unique # [itemaddclassskills] == 3 # [charmtier] == 100000",

--- a/libs/SoloPlay/Functions/DynamicTiers.js
+++ b/libs/SoloPlay/Functions/DynamicTiers.js
@@ -633,8 +633,13 @@ const secondaryscore = function (item) {
 };
 
 const charmscore = function (item) {
+	if (myData.me.charmGids.includes(item.gid)) return 1000;
 	let charmRating = 1;
-	charmRating += item.getStatEx(188, Check.currentBuild().tabSkills) * tierWeights.charmWeights.TAB; // + TAB skills
+	let skillerStats = [[0, 1, 2], [8, 9, 10], [16, 17, 18], [24, 25, 26], [32, 33, 34], [40, 41, 42], [48, 49, 50]][me.classid];
+	if (!item.unique && item.classid === sdk.items.GrandCharm && !skillerStats.some(s => item.getStatEx(188, s))) return -1;
+	const buildInfo = Check.currentBuild();
+
+	charmRating += item.getStatEx(188, buildInfo.tabSkills) * tierWeights.charmWeights.TAB; // + TAB skills
 	charmRating += item.getStatEx(39) * tierWeights.charmWeights.FR; // add FR
 	charmRating += item.getStatEx(43) * tierWeights.charmWeights.CR; // add CR
 	charmRating += item.getStatEx(41) * tierWeights.charmWeights.LR; // add LR
@@ -648,7 +653,7 @@ const charmscore = function (item) {
 	charmRating += item.getStatEx(0) * tierWeights.charmWeights.STR; // add STR
 	charmRating += item.getStatEx(2) * tierWeights.charmWeights.DEX; // add DEX
 
-	if (!Check.currentBuild().caster) {
+	if (!buildInfo.caster) {
 		charmRating += item.getStatEx(21) * 3; // add MIN damage
 		charmRating += item.getStatEx(22) * 3; // add MAX damage
 		charmRating += (item.getStatEx(48) + item.getStatEx(49) + item.getStatEx(50) + item.getStatEx(51) + item.getStatEx(52) + item.getStatEx(53) + item.getStatEx(54) + item.getStatEx(55) + (item.getStatEx(57) * 125 / 256)); // add elemental damage PSN damage adjusted for damage per frame (125/256)
@@ -656,7 +661,7 @@ const charmscore = function (item) {
 	}
 
 	// Gheeds, Torch, annhi
-	if (item.quality === 7) {
+	if (item.unique) {
 		charmRating += item.getStatEx(127) * tierWeights.charmWeights.ALL; // + all skills
 		charmRating += item.getStatEx(83, me.classid) * tierWeights.charmWeights.CLASS; // + class skills
 		charmRating += item.getStatEx(79); // add gold find

--- a/libs/SoloPlay/Functions/Globals.js
+++ b/libs/SoloPlay/Functions/Globals.js
@@ -54,7 +54,34 @@ function updateMyData () {
 }
 
 function ensureData () {
+	if (!myData.me.charms || !Object.keys(myData.me.charms).length) {
+		myData.me.charms = Check.finalBuild().finalCharms;
+		CharData.updateData("me", myData) && updateMyData();
+	}
+
+	if (!myData.me.charmGids) {
+		myData.me.charmGids = [];
+		CharData.updateData("me", myData) && updateMyData();
+	}
+
+	const finalCharmKeys = Object.keys(myData.me.charms);
+	let gidCheck = [];
+
+	for (let i = 0; i < finalCharmKeys.length; i++) {
+		let cKey = finalCharmKeys[i];
+		if (myData.me.charms[cKey].have.length) {
+			gidCheck = gidCheck.concat(myData.me.charms[cKey].have);
+			console.debug(gidCheck);
+			console.debug(myData.me.charmGids);
+		}
+	}
+
 	let temp = Misc.copy(myData);
+	
+	if (!myData.me.charmGids.equals(gidCheck)) {
+		myData.me.charmGids = myData.me.charmGids.concat(gidCheck);
+		CharData.updateData("me", myData) && updateMyData();
+	}
 
 	if (myData.me.currentBuild !== SetUp.getBuild()) {
 		switch (true) {
@@ -65,6 +92,7 @@ function ensureData () {
 			break;
 		case !["Start", "Stepping", "Leveling"].includes(SetUp.getBuild()) && myData.me.currentBuild !== myData.me.finalBuild:
 			myData.me.currentBuild = "Leveling";
+			myData.me.charms = {};
 
 			break;
 		}
@@ -1193,6 +1221,7 @@ const Check = {
 			mercAct: final ? finalBuild.mercAct : null,
 			mercAuraWanted: final ? finalBuild.mercAuraWanted : null,
 			finalGear: final ? finalBuild.autoEquipTiers : [],
+			finalCharms: (finalBuild.charms || {}),
 			respec: final ? finalBuild.respec : () => {},
 			active: final ? finalBuild.active : build.active,
 		};
@@ -1268,6 +1297,7 @@ const Check = {
 			mercAct: finalBuild.mercAct,
 			mercAuraWanted: finalBuild.mercAuraWanted,
 			finalGear: finalBuild.autoEquipTiers,
+			finalCharms: (finalBuild.charms || {}),
 			respec: finalBuild.respec,
 			active: finalBuild.active,
 		};

--- a/libs/SoloPlay/Functions/Globals.js
+++ b/libs/SoloPlay/Functions/Globals.js
@@ -59,29 +59,29 @@ function ensureData () {
 		CharData.updateData("me", myData) && updateMyData();
 	}
 
+	let cUpdate = false;
+
 	if (!myData.me.charmGids) {
 		myData.me.charmGids = [];
 		CharData.updateData("me", myData) && updateMyData();
+	} else if (myData.me.charmGids.length > 0) {
+		// gids change from game to game so reset our list
+		myData.me.charmGids = [];
+		cUpdate = true;
 	}
 
 	const finalCharmKeys = Object.keys(myData.me.charms);
-	let gidCheck = [];
-
+	// gids change from game to game so reset our list
 	for (let i = 0; i < finalCharmKeys.length; i++) {
 		let cKey = finalCharmKeys[i];
 		if (myData.me.charms[cKey].have.length) {
-			gidCheck = gidCheck.concat(myData.me.charms[cKey].have);
-			console.debug(gidCheck);
-			console.debug(myData.me.charmGids);
+			myData.me.charms[cKey].have = [];
+			cUpdate = true;
 		}
 	}
 
+	cUpdate && updateMyData();
 	let temp = Misc.copy(myData);
-	
-	if (!myData.me.charmGids.equals(gidCheck)) {
-		myData.me.charmGids = myData.me.charmGids.concat(gidCheck);
-		CharData.updateData("me", myData) && updateMyData();
-	}
 
 	if (myData.me.currentBuild !== SetUp.getBuild()) {
 		switch (true) {

--- a/libs/SoloPlay/Functions/ItemOverrides.js
+++ b/libs/SoloPlay/Functions/ItemOverrides.js
@@ -861,6 +861,10 @@ Item.hasCharmTier = function (item) {
 	return me.expansion && Config.AutoEquip && NTIP.GetCharmTier(item) > 0;
 };
 
+Item.isFinalCharm = function (item) {
+	return myData.me.charmGids.includes(item.gid);
+};
+
 // Iterate over charm checklist, pickit result 0 and 4 get sold
 // Otherwise if its not in the stash already and not a final charm try and stash it. I don't remember why I checked if it wasn't a final charm
 const spliceCharmCheckList = function (checkList = [], verbose = false) {
@@ -1127,7 +1131,7 @@ Item.autoEquipCharmSort = function (items = [], verbose = false) {
 	}
 
 	if (found) {
-		CharData.updateData("me", myData) && updateMyData();
+		updateMyData();
 	}
 
 	if (!charms.skillerTypeA.length && !charms.skillerTypeB.length && !charms.skillerTypeC.length
@@ -1275,9 +1279,7 @@ Item.initCharms = function () {
 		}
 	}
 
-	if (changed) {
-		CharData.updateData("me", myData) && updateMyData();
-	}
+	changed && updateMyData();
 };
 
 Item.autoEquipCharms = function () {

--- a/libs/SoloPlay/Functions/MiscOverrides.js
+++ b/libs/SoloPlay/Functions/MiscOverrides.js
@@ -833,7 +833,7 @@ Misc.updateRecursively = function (oldObj, newObj, path) {
 			}
 		} else if (Array.isArray(newObj[key]) && !newObj[key].some(k => typeof k === "object")) {
 			// copy array (shallow copy)
-			if (!oldObj[key].equals(newObj[key])) {
+			if (oldObj[key] === undefined || !oldObj[key].equals(newObj[key])) {
 				oldObj[key] = newObj[key].slice(0);
 			}
 		} else {

--- a/libs/SoloPlay/Functions/NTIPOverrides.js
+++ b/libs/SoloPlay/Functions/NTIPOverrides.js
@@ -1,3 +1,4 @@
+/* eslint-disable dot-notation */
 /**
 *  @filename    NTIPOverrides.js
 *  @author      theBGuy, isid0re
@@ -74,7 +75,6 @@ NTIP.addLine = function (itemString) {
 	};
 
 	let line = NTIP.ParseLineInt(itemString, info);
-	NTIP.setUpFinalCharmQuantity(itemString, info);
 
 	if (line) {
 		if (!itemString.toLowerCase().includes("tier")) {
@@ -98,19 +98,13 @@ NTIP.arrayLooping = function (arraytoloop) {
 	return true;
 };
 
-NTIP.hasStats = function (item, entryList, verbose) {
-	let list, identified, hasStat = false, line = "", stats;
-
-	if (!entryList) {
-		list = NTIP_CheckList;
-	} else {
-		list = entryList;
-	}
-
-	identified = item.getFlag(0x10);
+NTIP.hasStats = function (item, entryList = [], verbose = false) {
+	let hasStat = false, line = "", stats;
+	let list = entryList.length ? entryList : NTIP_CheckList;
 
 	for (let i = 0; i < list.length; i++) {
 		try {
+			// eslint-disable-next-line no-unused-vars
 			let [type, stat, wanted] = list[i];
 
 			if (typeof type === 'function') {
@@ -139,49 +133,32 @@ NTIP.hasStats = function (item, entryList, verbose) {
 	}
 
 	if (hasStat && verbose) {
-		print(stats);
+		console.debug(stats);
+		console.debug(line);
 	}
 
 	return hasStat;
 };
 
-NTIP.getInvoQuantity = function (item, entryList) {
-	let i, list, identified,
-		invoquantity = -1;
+NTIP.getInvoQuantity = function (item, entryList = []) {
+	let invoquantity = -1;
+	let list = entryList.length ? entryList : NTIP_CheckList;
 
-	if (!entryList) {
-		list = NTIP_CheckList;
-	} else {
-		list = entryList;
-	}
+	for (let i = 0; i < list.length; i++) {
+		try {
+			let [type, stat, wanted] = list[i];
 
-	identified = item.getFlag(0x10);
-
-	if (!NTIP.checkFinalCharm(item)) {
-		for (i = 0; i < list.length; i++) {
-			try {
-				let [type, stat, wanted] = list[i];
-
-				if (typeof type === 'function') {
-					if (type(item)) {
-						if (typeof stat === 'function') {
-							if (stat(item)) {
-								if (wanted && wanted.InvoQuantity && !isNaN(wanted.InvoQuantity)) {
-									invoquantity = wanted.InvoQuantity;
-
-									break;
-								}
-							}
-						} else {
+			if (typeof type === 'function') {
+				if (type(item)) {
+					if (typeof stat === 'function') {
+						if (stat(item)) {
 							if (wanted && wanted.InvoQuantity && !isNaN(wanted.InvoQuantity)) {
 								invoquantity = wanted.InvoQuantity;
 
 								break;
 							}
 						}
-					}
-				} else if (typeof stat === 'function') {
-					if (stat(item)) {
+					} else {
 						if (wanted && wanted.InvoQuantity && !isNaN(wanted.InvoQuantity)) {
 							invoquantity = wanted.InvoQuantity;
 
@@ -189,61 +166,28 @@ NTIP.getInvoQuantity = function (item, entryList) {
 						}
 					}
 				}
-			} catch (e) {
-				return -1;
-			}
-		}
-	} else {
-		for (i = list.length - 1; i >= 0; i--) {
-			try {
-				let [type, stat, wanted] = list[i];
+			} else if (typeof stat === 'function') {
+				if (stat(item)) {
+					if (wanted && wanted.InvoQuantity && !isNaN(wanted.InvoQuantity)) {
+						invoquantity = wanted.InvoQuantity;
 
-				if (typeof type === 'function') {
-					if (type(item)) {
-						if (typeof stat === 'function') {
-							if (stat(item)) {
-								if (wanted && wanted.InvoQuantity && !isNaN(wanted.InvoQuantity)) {
-									invoquantity = wanted.InvoQuantity;
-
-									break;
-								}
-							}
-						} else {
-							if (wanted && wanted.InvoQuantity && !isNaN(wanted.InvoQuantity)) {
-								invoquantity = wanted.InvoQuantity;
-
-								break;
-							}
-						}
-					}
-				} else if (typeof stat === 'function') {
-					if (stat(item)) {
-						if (wanted && wanted.InvoQuantity && !isNaN(wanted.InvoQuantity)) {
-							invoquantity = wanted.InvoQuantity;
-
-							break;
-						}
+						break;
 					}
 				}
-			} catch (e) {
-				return -1;
 			}
+		} catch (e) {
+			return -1;
 		}
 	}
 
 	return invoquantity;
 };
 
-NTIP.getMaxQuantity = function (item, entryList, verbose) {
-	let i, list, maxquantity = -1;
+NTIP.getMaxQuantity = function (item, entryList = []) {
+	let maxquantity = -1;
+	let list = entryList.length ? entryList : NTIP_CheckList;
 
-	if (!entryList) {
-		list = NTIP_CheckList;
-	} else {
-		list = entryList;
-	}
-
-	for (i = 0; i < list.length; i++) {
+	for (let i = 0; i < list.length; i++) {
 		try {
 			let [type, stat, wanted] = list[i];
 
@@ -282,200 +226,12 @@ NTIP.getMaxQuantity = function (item, entryList, verbose) {
 	return maxquantity;
 };
 
-NTIP.checkFinalCharm = function (item, entryList) {
-	let i, list, identified,
-		finalcharm = false;
-
-	if (!entryList) {
-		list = NTIP_CheckList;
-	} else {
-		list = entryList;
-	}
-
-	identified = item.getFlag(0x10);
-
-	for (i = 0; i < list.length; i++) {
-		try {
-			let [type, stat, wanted] = list[i];
-
-			if (typeof type === 'function') {
-				if (type(item)) {
-					if (typeof stat === 'function') {
-						if (stat(item)) {
-							if (wanted && wanted.FinalCharm && !isNaN(wanted.FinalCharm)) {
-								finalcharm = wanted.FinalCharm;
-								
-								break;
-							}
-						}
-					} else {
-						if (wanted && wanted.FinalCharm && !isNaN(wanted.FinalCharm)) {
-							finalcharm = wanted.FinalCharm;
-
-							break;
-						}
-					}
-				}
-			} else if (typeof stat === 'function') {
-				if (stat(item)) {
-					if (wanted && wanted.FinalCharm && !isNaN(wanted.FinalCharm)) {
-						finalcharm = wanted.FinalCharm;
-
-						break;
-					}
-				}
-			}
-		} catch (e) {
-			return false;
-		}
-	}
-
-	return finalcharm;
-};
-
-NTIP.setUpFinalCharmQuantity = function (input, info) {
-	let i, property, p_start, p_end, p_section, p_keyword, p_result, value;
-	let charmType;
-
-	p_end = input.indexOf("//");
-
-	if (p_end !== -1) {
-		input = input.substring(0, p_end);
-	}
-
-	input = input.replace(/\s+/g, "").toLowerCase();
-
-	if (input.length < 5) {
-		return null;
-	}
-
-	p_result = input.split("#");
-
-	if (p_result[0] && p_result[0].length > 4) {
-		p_section = p_result[0].split("[");
-
-		p_result[0] = p_section[0];
-
-		for (i = 1; i < p_section.length; i += 1) {
-			p_end = p_section[i].indexOf("]") + 1;
-			property = p_section[i].substring(0, p_end - 1);
-
-			if (property === 'name') {
-				p_result[0] += "item.classid";
-			} else {
-				continue;
-			}
-
-			for (p_start = p_end; p_end < p_section[i].length; p_end += 1) {
-				if (!NTIP.IsSyntaxInt(p_section[i][p_end])) {
-					break;
-				}
-			}
-
-			p_result[0] += p_section[i].substring(p_start, p_end);
-
-			if (p_section[i].substring(p_start, p_end) === "=") {
-				Misc.errorReport("Unexpected = at line " + info.line + " in " + info.file);
-
-				return false;
-			}
-
-			for (p_start = p_end; p_end < p_section[i].length; p_end += 1) {
-				if (NTIP.IsSyntaxInt(p_section[i][p_end])) {
-					break;
-				}
-			}
-
-			p_keyword = p_section[i].substring(p_start, p_end);
-
-			if (isNaN(p_keyword)) {
-				switch (property) {
-				case 'name':
-					if (NTIPAliasClassID[p_keyword] === undefined) {
-						Misc.errorReport("Unknown type: " + p_keyword + " File: " + info.file + " Line: " + info.line);
-
-						return false;
-					}
-
-					charmType = NTIPAliasClassID[p_keyword];
-
-					if ([603, 604, 605].indexOf(charmType) === -1) {
-						return false;
-					}
-
-					break;
-				}
-			}
-		}
-	} else {
-		p_result[0] = "";
-	}
-
-	if (p_result[2] && p_result[2].length > 0) {
-		p_section = p_result[2].split("[");
-		p_result[2] = {};
-
-		for (i = 1; i < p_section.length; i += 1) {
-			p_end = p_section[i].indexOf("]");
-			p_keyword = p_section[i].substring(0, p_end);
-
-			let keyword = p_keyword.toLowerCase();
-
-			switch (keyword) {
-			case "invoquantity":
-				value = Number(p_section[i].split("==")[1].match(/\d+/g));
-
-				if (!isNaN(value)) {
-					p_result[2].InvoQuantity = value;
-				}
-
-				break;
-			case "finalcharm":
-				let check = Boolean(p_section[i].split("==")[1].match(/(\b(?!split\b)[^ $]+\b)/g));
-
-				if (!isNaN(check)) {
-					p_result[2].FinalCharm = check;
-				}
-
-				break;
-			}
-		}
-
-		if (!!p_result[2].InvoQuantity && !!p_result[2].FinalCharm) {
-			if (p_result[2].FinalCharm === true) {
-				switch (charmType) {
-				case 603:
-					Item.maxFinalSCs += p_result[2].InvoQuantity;
-
-					break;
-				case 604:
-					Item.maxFinalLCs += p_result[2].InvoQuantity;
-
-					break;
-				case 605:
-					Item.maxFinalGCs += p_result[2].InvoQuantity;
-
-					break;
-				}
-			}
-		}
-	}
-
-	return true;
-};
-
-NTIP.CheckItem = function (item, entryList, verbose) {
-	let i, list, identified, num,
-		rval = {},
-		result = 0;
-
-	if (!entryList) {
-		list = NTIP_CheckList;
-	} else {
-		list = entryList;
-	}
-
-	identified = item.getFlag(0x10);
+NTIP.CheckItem = function (item, entryList = [], verbose = false) {
+	let i, num;
+	let rval = {};
+	let result = 0;
+	let list = entryList.length ? entryList : NTIP_CheckList;
+	let identified = item.getFlag(0x10);
 
 	for (i = 0; i < list.length; i++) {
 		try {
@@ -494,7 +250,8 @@ NTIP.CheckItem = function (item, entryList, verbose) {
 
 									break;
 								} else {
-									if (item.getParent() && item.getParent().name === me.name && item.mode === 0 && num === wanted.MaxQuantity) { // attempt at inv fix for maxquantity
+									// attempt at inv fix for maxquantity
+									if (item.getParent() && item.getParent().name === me.name && item.mode === 0 && num === wanted.MaxQuantity) {
 										result = 1;
 
 										break;
@@ -521,7 +278,8 @@ NTIP.CheckItem = function (item, entryList, verbose) {
 
 								break;
 							} else {
-								if (item.getParent() && item.getParent().name === me.name && item.mode === 0 && num === wanted.MaxQuantity) { // attempt at inv fix for maxquantity
+								// attempt at inv fix for maxquantity
+								if (item.getParent() && item.getParent().name === me.name && item.mode === 0 && num === wanted.MaxQuantity) {
 									result = 1;
 
 									break;
@@ -544,7 +302,8 @@ NTIP.CheckItem = function (item, entryList, verbose) {
 
 							break;
 						} else {
-							if (item.getParent() && item.getParent().name === me.name && item.mode === 0 && num === wanted.MaxQuantity) { // attempt at inv fix for maxquantity
+							// attempt at inv fix for maxquantity
+							if (item.getParent() && item.getParent().name === me.name && item.mode === 0 && num === wanted.MaxQuantity) {
 								result = 1;
 
 								break;
@@ -613,37 +372,31 @@ NTIP.OpenFile = function (filepath, notify) {
 		return false;
 	}
 
-	let i, nipfile, line, lines, info, tick = getTickCount(), entries = 0,
-		filename = filepath.substring(filepath.lastIndexOf("/") + 1, filepath.length);
+	let nipfile, tick = getTickCount(), entries = 0;
+	let filename = filepath.substring(filepath.lastIndexOf("/") + 1, filepath.length);
 
 	try {
 		nipfile = File.open(filepath, 0);
 	} catch (fileError) {
-		if (notify) {
-			Misc.errorReport("ÿc1Failed to load NIP: ÿc0" + filename);
-		}
+		notify && Misc.errorReport("ÿc1Failed to load NIP: ÿc0" + filename);
 	}
 
-	if (!nipfile) {
-		return false;
-	}
+	if (!nipfile) return false;
 
-	lines = nipfile.readAllLines();
-
+	let lines = nipfile.readAllLines();
 	nipfile.close();
 
-	for (i = 0; i < lines.length; i += 1) {
-		info = {
+	for (let i = 0; i < lines.length; i += 1) {
+		let info = {
 			line: i + 1,
 			file: filename,
 			string: lines[i]
 		};
 
-		line = NTIP.ParseLineInt(lines[i], info);
+		let line = NTIP.ParseLineInt(lines[i], info);
 
 		if (line) {
 			entries += 1;
-
 			NTIP_CheckList.push(line);
 
 			if (!lines[i].toLowerCase().match("tier")) {

--- a/libs/SoloPlay/Functions/PrototypeOverrides.js
+++ b/libs/SoloPlay/Functions/PrototypeOverrides.js
@@ -74,6 +74,12 @@ Unit.prototype.getItemType = function () {
 };
 
 Object.defineProperties(Unit.prototype, {
+	isCharm: {
+		get: function () {
+			if (this.type !== sdk.unittype.Item) return false;
+			return [sdk.items.SmallCharm, sdk.items.LargeCharm, sdk.items.GrandCharm].includes(this.classid);
+		},
+	},
 	isRuneword: {
 		get: function () {
 			if (this.type !== sdk.unittype.Item) return false;
@@ -200,6 +206,16 @@ Object.defineProperties(Unit.prototype, {
 			return Math.max(getBaseStat("items", id, "levelreq"), 0);
 		}
 	},
+	allRes: {
+		get: function () {
+			if (this.type !== sdk.unittype.Item) return 0;
+			let fr = this.getStat(sdk.stats.FireResist);
+			let cr = this.getStat(sdk.stats.ColdResist);
+			let lr = this.getStat(sdk.stats.LightningResist);
+			let pr = this.getStat(sdk.stats.PoisonResist);
+			return (fr && cr && lr && pr) ? fr : 0;
+		}
+	}
 });
 
 Object.defineProperties(me, {

--- a/libs/SoloPlay/SoloPlay.js
+++ b/libs/SoloPlay/SoloPlay.js
@@ -65,6 +65,9 @@ function SoloPlay () {
 					Item.removeItem(null, item);
 				}
 			});
+		
+		// initialize final charms if we have any
+		Item.initCharms();
 
 		return true;
 	};

--- a/libs/SoloPlay/Threads/ToolsThread.js
+++ b/libs/SoloPlay/Threads/ToolsThread.js
@@ -514,7 +514,7 @@ function main () {
 									" | ÿc4AutoEquipKeepCheckMerc: ÿc0" + Item.autoEquipKeepCheckMerc(itemToCheck) + "\nÿc4Cubing Item: ÿc0" + Cubing.keepItem(itemToCheck) +
 									" | ÿc4Runeword Item: ÿc0" + Runewords.keepItem(itemToCheck) + " | ÿc4Crafting Item: ÿc0" + CraftingSystem.keepItem(itemToCheck) + " | ÿc4SoloWants Item: ÿc0" + SoloWants.keepItem(itemToCheck) +
 									"\nÿc4ItemType: ÿc0" + itemToCheck.itemType + "| ÿc4Classid: ÿc0" + itemToCheck.classid + "| ÿc4Quality: ÿc0" + itemToCheck.quality;
-					charmString = "ÿc4InvoQuantity: ÿc0" + NTIP.getInvoQuantity(itemToCheck) + " | ÿc4hasStats: ÿc0" + NTIP.hasStats(itemToCheck) + " | ÿc4FinalCharm: ÿc0" + NTIP.checkFinalCharm(itemToCheck) + "\n" +
+					charmString = "ÿc4InvoQuantity: ÿc0" + NTIP.getInvoQuantity(itemToCheck) + " | ÿc4hasStats: ÿc0" + NTIP.hasStats(itemToCheck) + " | ÿc4FinalCharm: ÿc0" + Item.isFinalCharm(itemToCheck) + "\n" +
 							"ÿc4CharmType: ÿc0" + Item.getCharmType(itemToCheck) + " | ÿc4AutoEquipCharmCheck: ÿc0" + Item.autoEquipCharmCheck(itemToCheck) + " | ÿc4CharmTier: ÿc0" + NTIP.GetCharmTier(itemToCheck);
 					generalString = "ÿc4ItemName: ÿc0" + itemToCheck.fname.split("\n").reverse().join(" ").replace(/ÿc[0-9!"+<;.*]/, "")
 						+ "\nÿc4Pickit: ÿc0" + Pickit.checkItem(itemToCheck).result + " | ÿc4NTIP.CheckItem: ÿc0" + NTIP.CheckItem(itemToCheck, false, true).result + " | ÿc4NTIP.CheckItem No Tier: ÿc0" + NTIP.CheckItem(itemToCheck, NTIP_CheckListNoTier, true).result;

--- a/libs/SoloPlay/Tools/CharData.js
+++ b/libs/SoloPlay/Tools/CharData.js
@@ -34,13 +34,78 @@ const CharData = {
 			currentBuild: "Start",
 			finalBuild: "",
 			highestDifficulty: "Normal",
-			setDifficulty: "Normal"
+			setDifficulty: "Normal",
+			charms: {},
+			charmGids: [],
 		},
 		merc: {
 			act: 1,
 			classid: 271,
 			difficulty: 0,
 			type: "",
+		}
+	},
+
+	charmData: {
+		small: {
+			getCountInfo: function () {
+				const finalCharmKeys = Object.keys(myData.me.charms);
+				let curr = 0;
+				let max = 0;
+
+				for (let i = 0; i < finalCharmKeys.length; i++) {
+					let cKey = finalCharmKeys[i];
+					if (myData.me.charms[cKey].classid === sdk.items.SmallCharm) {
+						curr += myData.me.charms[cKey].have.length;
+						max += myData.me.charms[cKey].max;
+					}
+				}
+
+				return {
+					curr: curr,
+					max: max
+				};
+			},
+		},
+		large: {
+			getCountInfo: function () {
+				const finalCharmKeys = Object.keys(myData.me.charms);
+				let curr = 0;
+				let max = 0;
+
+				for (let i = 0; i < finalCharmKeys.length; i++) {
+					let cKey = finalCharmKeys[i];
+					if (myData.me.charms[cKey].classid === sdk.items.LargeCharm) {
+						curr += myData.me.charms[cKey].have.length;
+						max += myData.me.charms[cKey].max;
+					}
+				}
+
+				return {
+					curr: curr,
+					max: max
+				};
+			},
+		},
+		grand: {
+			getCountInfo: function () {
+				const finalCharmKeys = Object.keys(myData.me.charms);
+				let curr = 0;
+				let max = 0;
+
+				for (let i = 0; i < finalCharmKeys.length; i++) {
+					let cKey = finalCharmKeys[i];
+					if (myData.me.charms[cKey].classid === sdk.items.GrandCharm) {
+						curr += myData.me.charms[cKey].have.length;
+						max += myData.me.charms[cKey].max;
+					}
+				}
+
+				return {
+					curr: curr,
+					max: max
+				};
+			},
 		}
 	},
 


### PR DESCRIPTION
- make finalCharms part of our chardata so we are able to keep track of them easier
- update/remove charms as needed during init process an ensureData check
- changing it so a charm that didn't meet the cut for being our final charm can be re-evaluated as a normal leveling charm. Had to move away from ntip because it sucks
- still think splitting up and sorting the charms can be done better but now once we have at least 75% of the small charms wanted we properly cap the amount extra in our inventory so we don't end up with 10+ charms
- added prototype for isCharm, so don;t have to do the same classid check 1000 times