### PR TITLE
Improve speed of checking for junk, along with various bug fixes

### DIFF
--- a/libs/SoloPlay/BuildFiles/Runewords/Silence.js
+++ b/libs/SoloPlay/BuildFiles/Runewords/Silence.js
@@ -14,7 +14,7 @@ if (me.getItem(sdk.items.runes.Vex)) {
 
 	// Have Ist+Vex rune but do not have a base yet
 	if (me.getItem(sdk.items.runes.Ist) && !Check.haveBase("phaseblade", 6)) {
-		NTIP.addLine("[name] == phaseblade && [quality] <= superior && [flag] != ethereal # [sockets] == 0 # [maxquantity] == 1");
+		NTIP.addLine("[name] == phaseblade && [quality] == normal && [flag] != ethereal # [sockets] == 0 # [maxquantity] == 1");
 		Config.Recipes.push([Recipe.Socket.Weapon, "phaseblade"]);
 	}
 }

--- a/libs/SoloPlay/Functions/ClassAttackOverrides/AmazonAttacks.js
+++ b/libs/SoloPlay/Functions/ClassAttackOverrides/AmazonAttacks.js
@@ -132,7 +132,8 @@ ClassAttack.doAttack = function (unit, preattack) {
 
 			// Handle Switch casting
 			if (!unit.dead) {
-				if (!unit.getState(sdk.states.LowerResist) && unit.curseable && commonCheck && !checkCollision(me, unit, 0x4)) {
+				if (CharData.skillData.chargedSkillsOnSwitch.some(chargeSkill => chargeSkill.skill === sdk.skills.LowerResist)
+					&& !unit.getState(sdk.states.LowerResist) && unit.curseable && commonCheck && !checkCollision(me, unit, 0x4)) {
 					// Switch cast lower resist
 					Attack.switchCastCharges(sdk.skills.LowerResist, unit);
 				}

--- a/libs/SoloPlay/Functions/PrototypeOverrides.js
+++ b/libs/SoloPlay/Functions/PrototypeOverrides.js
@@ -358,7 +358,7 @@ Unit.prototype.castChargedSkill = function (...args) {
 
 		if (skillId) {
 			if (charge instanceof Array) {
-				charge = charge.filter(item => (skillId && item.skill === skillId) && !!item.charges); // Filter out all other charged skills
+				charge = charge.filter(item => (item && item.skill === skillId) && !!item.charges); // Filter out all other charged skills
 				charge = charge.first();
 			} else {
 				if (charge.skill !== skillId || !charge.charges) {
@@ -948,9 +948,9 @@ if (!Array.prototype.equals) {
 		// if the other array is a falsy value, return
 		if (!array) return false;
 
-		// compare lengths - can save a lot of time 
+		// compare lengths - can save a lot of time
 		if (this.length !== array.length) return false;
-    
+
 		// call basic sort method, (my addition as I don't care if its the same order just if it contains the same values)
 		this.sort();
 		array.sort();

--- a/libs/SoloPlay/Functions/TownOverrides.js
+++ b/libs/SoloPlay/Functions/TownOverrides.js
@@ -2071,9 +2071,10 @@ Town.clearJunk = function () {
 
 	while (junkItems.length > 0) {
 		let junk = junkItems.shift();
+		const pickitResult = Pickit.checkItem(junk).result;
 
 		if ((junk.isInStorage) && // stash/invo/cube
-			([1, 2, 3, 5].indexOf(Pickit.checkItem(junk).result) === -1) &&
+			([1, 2, 3, 5].indexOf(pickitResult) === -1) &&
 			!AutoEquip.wanted(junk) && // Don't toss wanted auto equip items
 			!Cubing.keepItem(junk) && // Don't throw cubing ingredients
 			!Runewords.keepItem(junk) && // Don't throw runeword ingredients
@@ -2081,9 +2082,9 @@ Town.clearJunk = function () {
 			!SoloWants.keepItem(junk) && // Don't throw SoloWants system ingredients
 			!Town.ignoredItemTypes.includes(junk.itemType) && // Don't drop tomes, keys or potions
 			junk.sellable &&	// Don't try to sell/drop quest-items/keys/essences/tokens/organs
-			([0, 4].includes(Pickit.checkItem(junk).result)) // only drop unwanted or sellable
+			([0, 4].includes(pickitResult)) // only drop unwanted or sellable
 		) {
-			print("ÿc9JunkCheckÿc0 :: Junk: " + junk.name + " Pickit Result: " + Pickit.checkItem(junk).result);
+			print("ÿc9JunkCheckÿc0 :: Junk: " + junk.name + " Pickit Result: " + pickitResult);
 
 			!getUIFlag(sdk.uiflags.Stash) && junk.isInStash && Town.openStash();
 			junk.isInCube && Cubing.emptyCube();
@@ -2100,9 +2101,9 @@ Town.clearJunk = function () {
 			}
 		}
 
-		if (junk.isInStorage && junk.sellable) {
+		if (junk.isInStorage && junk.sellable && pickitResult !== 1) {
 			if (!junk.identified && !Cubing.keepItem(junk) && !CraftingSystem.keepItem(junk)) {
-				print("ÿc9UnidJunkCheckÿc0 :: Junk: " + junk.name + " Junk type: " + junk.itemType + " Pickit Result: " + Pickit.checkItem(junk).result);
+				print("ÿc9UnidJunkCheckÿc0 :: Junk: " + junk.name + " Junk type: " + junk.itemType + " Pickit Result: " + pickitResult);
 
 				!getUIFlag(sdk.uiflags.Stash) && junk.isInStash && Town.openStash();
 				junk.isInCube && Cubing.emptyCube();
@@ -2123,7 +2124,7 @@ Town.clearJunk = function () {
 				!getUIFlag(sdk.uiflags.Stash) && junk.isInStash && Town.openStash();
 				junk.isInCube && Cubing.emptyCube();
 
-				print("ÿc9AutoEquipJunkCheckÿc0 :: Junk: " + junk.name + " Junk type: " + junk.itemType + " Pickit Result: " + Pickit.checkItem(junk).result);
+				print("ÿc9AutoEquipJunkCheckÿc0 :: Junk: " + junk.name + " Junk type: " + junk.itemType + " Pickit Result: " + pickitResult);
 
 				if (junk.isInInventory || (Storage.Inventory.CanFit(junk) && Storage.Inventory.MoveTo(junk))) {
 					junkToSell.push(junk);
@@ -2139,7 +2140,7 @@ Town.clearJunk = function () {
 
 			if (junk.isBaseType) {
 				if (this.worseBaseThanStashed(junk, true)) {
-					print("ÿc9WorseBaseThanStashedCheckÿc0 :: Base: " + junk.name + " Junk type: " + junk.itemType + " Pickit Result: " + Pickit.checkItem(junk).result);
+					print("ÿc9WorseBaseThanStashedCheckÿc0 :: Base: " + junk.name + " Junk type: " + junk.itemType + " Pickit Result: " + pickitResult);
 					
 					!getUIFlag(sdk.uiflags.Stash) && junk.isInStash && Town.openStash();
 					junk.isInCube && Cubing.emptyCube();
@@ -2157,7 +2158,7 @@ Town.clearJunk = function () {
 				}
 
 				if (!this.betterBaseThanWearing(junk, Developer.debugging.junkCheck)) {
-					print("ÿc9BetterThanWearingCheckÿc0 :: Base: " + junk.name + " Junk type: " + junk.itemType + " Pickit Result: " + Pickit.checkItem(junk).result);
+					print("ÿc9BetterThanWearingCheckÿc0 :: Base: " + junk.name + " Junk type: " + junk.itemType + " Pickit Result: " + pickitResult);
 
 					!getUIFlag(sdk.uiflags.Stash) && junk.isInStash && Town.openStash();
 					junk.isInCube && Cubing.emptyCube();


### PR DESCRIPTION
Only call checkItem once in Town.clearJunk.
Don't sell something if its pickit result is 1 (wanted).
Fix Silence runeword so that 0 socket superior phase blades will not be picked up.
Fix bug in AmazonAttacks.js where it would try to cast lower resists without ensuring the player has an item with lower resist charges.
Fix small bug in castChargedSkill where it did not ensure that a valid item was returned by getStat.