### PR TITLE
Fix command not found in precastoverride.js

### DIFF
--- a/libs/SoloPlay/Functions/PrecastOverrides.js
+++ b/libs/SoloPlay/Functions/PrecastOverrides.js
@@ -31,7 +31,7 @@ new Overrides.Override(Precast, Precast.doPrecast, function (orignal, force) {
 		if (Skill.canUse(sdk.skills.HolyShield)
 			&& Math.round(Skill.getManaCost(sdk.skills.HolyShield) * 100 / me.mpmax) < 35
 			&& (!me.getState(sdk.states.HolyShield) || force)) {
-			Precast.cast(sdk.skills.HolyShield);
+			this.precastSkill(sdk.skills.HolyShield);
 		}
 
 		break;
@@ -45,10 +45,10 @@ new Overrides.Override(Precast, Precast.doPrecast, function (orignal, force) {
 			let {x, y} = me;
 			(needBo || needBc) && me.switchWeapons(this.getBetterSlot(sdk.skills.BattleOrders));
 
-			needBc && Precast.cast(sdk.skills.BattleCommand, x, y, true);
-			needBo && Precast.cast(sdk.skills.BattleOrders, x, y, true);
-			needShout && Precast.cast(sdk.skills.Shout, x, y, true);
-			needBc && Precast.cast(sdk.skills.BattleCommand, x, y, true);
+			needBc && this.precastSkill(sdk.skills.BattleCommand, x, y, true);
+			needBo && this.precastSkill(sdk.skills.BattleOrders, x, y, true);
+			needShout && this.precastSkill(sdk.skills.Shout, x, y, true);
+			needBc && this.precastSkill(sdk.skills.BattleCommand, x, y, true);
 
 			me.weaponswitch !== primary && me.switchWeapons(primary);
 		}


### PR DESCRIPTION
Not sure if it was meant to be edited this way, but Barbarian and Paladin do not play with the current "Precast.cast", but do start and run with "this.precastSkill".

I know this is the development version but I enjoy tinkering and signed up just to suggest this change, if something else should be modified instead of this, I'd be more than happy to jump that route instead.