### PR TITLE
Add checks in case logPerformance is disabled

### DIFF
--- a/D2BotSoloPlay.dbj
+++ b/D2BotSoloPlay.dbj
@@ -163,7 +163,7 @@ function timer (tick) {
 	const currInGame = (getTickCount() - tick);
 	let timeStr = " (Time: " + Time.format(currInGame) + ") ";
 	
-	if (Developer.displayClockInConsole) {
+	if (Developer.displayClockInConsole && Developer.logPerformance) {
 		try {
 			gameTracker === undefined && (gameTracker = Developer.readObj(Tracker.GTPath));
 			let [tTime, tInGame, tDays] = [(gameTracker.Total + currInGame), (gameTracker.InGame + currInGame), (gameTracker.Total + currInGame)];

--- a/libs/SoloPlay/Threads/ToolsThread.js
+++ b/libs/SoloPlay/Threads/ToolsThread.js
@@ -574,6 +574,10 @@ function main () {
 
 	let myAct = me.act;
 
+	if (Developer.overlay && !Developer.logPerformance) {
+		console.warn("Without logPerformance set, the overlay will only show partial values");
+	}
+
 	// Start
 	while (true) {
 		try {
@@ -671,8 +675,6 @@ function main () {
 						myAct = me.act;
 					}
 				}
-			} else {
-				D2Bot.printToConsole("Overlay cannot work without Developer.logPerformance = true;", sdk.colors.D2Bot.Blue);
 			}
 		}
 

--- a/libs/SoloPlay/Tools/Overlay.js
+++ b/libs/SoloPlay/Tools/Overlay.js
@@ -28,6 +28,7 @@ const Overlay = {
 		tick: 0,
 
 		clock: function () {
+			if (!Developer.logPerformance) return "";
 			this.GameTracker === undefined && (this.GameTracker = Developer.readObj(Tracker.GTPath));
 			this.tick = getTickCount();
 			let currInGame = getTickCount() - me.gamestarttime;
@@ -51,8 +52,6 @@ const Overlay = {
 			// Double check in case still got here before being ready
 			if (!me.gameReady && !me.ingame && !me.area) return;
 
-			this.GameTracker === undefined && (this.GameTracker = Developer.readObj(Tracker.GTPath));
-			
 			!this.getHook("dashboard") && this.add("dashboard");
 			!this.getHook("credits") && this.add("credits");
 			
@@ -64,11 +63,14 @@ const Overlay = {
 				}
 			}
 
-			if (!this.getHook("times")) {
-				this.add("times");
-			} else {
-				if (getTickCount() - this.tick >= 1000) {
-					this.getHook("times").hook.text = this.clock();
+			if (Developer.logPerformance) {
+				this.GameTracker === undefined && (this.GameTracker = Developer.readObj(Tracker.GTPath));
+				if (!this.getHook("times")) {
+					this.add("times");
+				} else {
+					if (getTickCount() - this.tick >= 1000) {
+						this.getHook("times").hook.text = this.clock();
+					}
 				}
 			}
 

--- a/libs/SoloPlay/Tools/Tracker.js
+++ b/libs/SoloPlay/Tools/Tracker.js
@@ -172,7 +172,7 @@ const Tracker = {
 	}
 };
 
-if (getScript(true).name.toString() === "libs\\soloplay\\soloplay.js") {
+if (Developer.logPerformance && getScript(true).name.toString() === "libs\\soloplay\\soloplay.js") {
 	const Worker = require("../../modules/Worker");
 
 	Worker.runInBackground.intervalUpdate = function () {


### PR DESCRIPTION
- allow still showing the values in the overlay that don't depend on the performance tracking files
- change d2bot# warning print to console.warn print about logPerformance being disabled and its affect on the overlay