### PR TITLE
fix: Fix import order and make sort more compliant

### DIFF
--- a/libs/SoloPlay/Functions/Globals.js
+++ b/libs/SoloPlay/Functions/Globals.js
@@ -259,7 +259,7 @@ const SetUp = {
     }
     Array.isArray(files) && files
       .filter(file => file.endsWith(".js"))
-      .sort(a => a.startsWith("PrototypeOverrides.js") ? 0 : 1) // Dirty fix to load new prototypes first
+      .sort(a => a.startsWith("PrototypeOverrides.js") || a.startsWith("Mercenary.js") ? -1 : 1) // Dirty fix to load new prototypes first
       .forEach(function (x) {
         if (!isIncluded("SoloPlay/Functions/" + x)) {
           if (!include("SoloPlay/Functions/" + x)) {

--- a/libs/SoloPlay/Functions/Globals.js
+++ b/libs/SoloPlay/Functions/Globals.js
@@ -257,9 +257,14 @@ const SetUp = {
         delay(50);
       }
     }
+    
+    includeIfNotIncluded("SoloPlay/Functions/PrototypeOverrides.js");
+    includeIfNotIncluded("SoloPlay/Functions/Mercenary.js");
+
     Array.isArray(files) && files
-      .filter(file => file.endsWith(".js"))
-      .sort(a => a.startsWith("PrototypeOverrides.js") || a.startsWith("Mercenary.js") ? -1 : 1) // Dirty fix to load new prototypes first
+      .filter(function (file) {
+        return file.endsWith(".js");
+      })
       .forEach(function (x) {
         if (!isIncluded("SoloPlay/Functions/" + x)) {
           if (!include("SoloPlay/Functions/" + x)) {
@@ -294,7 +299,9 @@ const SetUp = {
     ],
   },
 
+  /** @type {string} */
   currentBuild: this.currentBuild,
+  /** @type {string} */
   finalBuild: this.finalBuild,
 
   // setter for Developer option to stop a profile once it reaches a certain level


### PR DESCRIPTION
If getFiles returns output alphabetically, autobuild.js is imported, which calls me.currentBuild, which then tries to load the build scripts, which then access MercData.

For that reason, import Mercenary.js early.

~Furthermore, .sort callback should be anti-symmetric, which I think it is not in this case, which depending on the sort implementation, might refuse to sort the outputs.~

~https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#description~