### PR TITLE
Add InvTrans property to logged items

### DIFF
--- a/Core/ItemOverrides.js
+++ b/Core/ItemOverrides.js
@@ -1007,6 +1007,7 @@ Item.logItem = function (action, unit, keptLine, force) {
     image: code,
     textColor: unit.quality,
     itemColor: color,
+    invTrans: (getBaseStat("items", unit.classid, "InvTrans") || 0),
     header: "",
     sockets: this.getItemSockets(unit)
   };

--- a/Core/MuleloggerOverrides.js
+++ b/Core/MuleloggerOverrides.js
@@ -94,6 +94,7 @@ MuleLogger.logItem = function (unit, logIlvl, type = "Player") {
 
   return {
     itemColor: color,
+    invTrans: (getBaseStat("items", unit.classid, "InvTrans") || 0),
     image: code,
     title: name,
     description: desc,


### PR DESCRIPTION
This is one of the reasons why items such as Tal Mask logged to D2Bot have a weird tint.
D2Bot manager only ships a single palette file (yet there are 6 or so), and ends up rendering it wrong.
This adds the required info so that some undescribed, other manager, could render it correctly.